### PR TITLE
Usage of GeneratorTestHelper from arbitrary packages

### DIFF
--- a/generator/src/main/java/org/stjs/generator/utils/GeneratorTestHelper.java
+++ b/generator/src/main/java/org/stjs/generator/utils/GeneratorTestHelper.java
@@ -197,7 +197,7 @@ public final class GeneratorTestHelper {
 		ClassWithJavascript stjsClass = gen.generateJavascript(Thread.currentThread().getContextClassLoader(), clazz.getName(), new File(
 				sourcePath), generationFolder, new File("target", "test-classes"),
 				new GeneratorConfigurationBuilder().allowedPackage("org.stjs.javascript").allowedPackage("org.stjs.generator")
-						.generateSourceMap(withSourceMap).build());
+						.allowedPackage(clazz.getPackage().getName()).generateSourceMap(withSourceMap).build());
 		Timers.start("js-exec");
 		List<File> javascriptFiles = new ArrayList<File>();
 		try {


### PR DESCRIPTION
allow to use the GeneratorTestHelper for unit tests in arbitrary packages (not only `org.stjs.javascript` and `org.stjs.generator`) by adding the package name of the passed class to the allowed packages
