### PR TITLE
Parsing of firefox' stacktrace

### DIFF
--- a/generator/src/test/java/org/stjs/generator/sourcemap/StacktraceTest.java
+++ b/generator/src/test/java/org/stjs/generator/sourcemap/StacktraceTest.java
@@ -10,15 +10,37 @@ import org.junit.Test;
 public class StacktraceTest {
 
 	@Test
-	public void testStacktraceBuild() {
+	public void testStacktraceUniversalBuild() {
 		// given
 		generateWithSourcemap(Sourcemap1.class);
 		generateWithSourcemap(Sourcemap2.class);
 
 		// when
-		String jsError = "at prototype.method2 (http://localhost:8055/org/stjs/generator/sourcemap/Sourcemap2.js:4:11)\n" //
+		String jsError = "Error: expected 'something strange'\n"
+				+ "at prototype.method2 (http://localhost:8055/org/stjs/generator/sourcemap/Sourcemap2.js:4:11)\n" //
 				+ "at prototype.method1 (http://localhost:8055/org/stjs/generator/sourcemap/Sourcemap1.js:5:11)\n" //
 				+ "at window.onload (http://localhost:8055/url?browserId=2430328:17:16)";
+		JavascriptToJava js2java = new JavascriptToJava(buildClassLoader());
+		StackTraceElement[] elements = js2java.buildStacktrace(jsError, "\n");
+
+		// then
+		assertNotNull(elements);
+		assertEquals("elements size", 3, elements.length);
+		assertElement(Sourcemap2.class, "/org/stjs/generator/sourcemap/Sourcemap2.java", "method2", 6, elements[0]);
+		assertElement(Sourcemap1.class, "/org/stjs/generator/sourcemap/Sourcemap1.java", "method1", 6, elements[1]);
+		assertElement(null, "/url?browserId=2430328", "onload", 17, elements[2]);
+	}
+
+	@Test
+	public void testStacktraceFirefoxBuild() {
+		// given
+		generateWithSourcemap(Sourcemap1.class);
+		generateWithSourcemap(Sourcemap2.class);
+
+		// when
+		String jsError = "prototype.method2@http://localhost:8055/org/stjs/generator/sourcemap/Sourcemap2.js:4:11\n" //
+				+ "prototype.method1@http://localhost:8055/org/stjs/generator/sourcemap/Sourcemap1.js:5:11\n" //
+				+ "window.onload@http://localhost:8055/url?browserId=2430328:17:16";
 		JavascriptToJava js2java = new JavascriptToJava(buildClassLoader());
 		StackTraceElement[] elements = js2java.buildStacktrace(jsError, "\n");
 

--- a/test-helper/src/main/resources/start.html
+++ b/test-helper/src/main/resources/start.html
@@ -41,10 +41,10 @@
 		if (result != "OK" && console) {
 			var errorStack = printStackTrace({e:result});
 			console.error(errorStack.join("\n"));
-			//take first non-junit stack trace element
+            location = encodeURIComponent(errorStack.join(";"));
+            //take first non-junit stack trace element
 			errorStack.splice(0,1);
-			location = encodeURIComponent(errorStack.join(";"));
-			for(var i = 0; 1 < errorStack.length; ++i){
+			for(var i = 0; i < errorStack.length; ++i){
 				if (errorStack[i].indexOf("junit.js") < 0) {
 					isAssert = (i > 1);
 					break;


### PR DESCRIPTION
- fixed bug when result param of GET getNextTest could have illegal characters.
- added unit test for stacktrace that comes from firefox and implemented this case at the code
