### PR TITLE
Don't generate Synthetic types

### DIFF
--- a/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/lambda/LambdaGeneratorTest.java
+++ b/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/lambda/LambdaGeneratorTest.java
@@ -48,7 +48,7 @@ public class LambdaGeneratorTest {
 
 	@Test
 	public void testLambaAccessMethodOuterScopeExecute() {
-		assertEquals(Integer.valueOf(4), execute(Lambda6b.class));
+		assertEquals(Double.valueOf(4.0), execute(Lambda6b.class));
 	}
 
 	@Test(expected = JavascriptFileGenerationException.class)

--- a/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/methodref/MethodReferenceGeneratorTest.java
+++ b/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/methodref/MethodReferenceGeneratorTest.java
@@ -10,20 +10,20 @@ public class MethodReferenceGeneratorTest {
 	@Test
 	public void testStaticMethodRef() {
 		assertCodeContains(MethodRef1.class, "calculate(MethodRef1.inc)");
-		assertEquals(Integer.valueOf(1), execute(MethodRef1.class));
+		assertEquals(Long.valueOf(1), execute(MethodRef1.class));
 	}
 
 	@Test
 	public void testInstanceMethodRef() {
 		assertCodeContains(MethodRef2.class,
 				"calculate(function(){return MethodRef2.prototype.inc2.call(arguments[0], arguments[1]);}, new MethodRef2(), 1)");
-		assertEquals(Integer.valueOf(3), execute(MethodRef2.class));
+		assertEquals(Double.valueOf(3.0), execute(MethodRef2.class));
 	}
 
 	@Test
 	public void testInstanceWithTargetMethodRef() {
 		assertCodeContains(MethodRef3.class, "calculate(stjs.bind(ref, \"inc2\"), 1)");
-		assertEquals(Integer.valueOf(4), execute(MethodRef3.class));
+		assertEquals(Double.valueOf(4.0), execute(MethodRef3.class));
 	}
 
 	@Test

--- a/generator/src/main/java/org/stjs/generator/SyntheticClass.java
+++ b/generator/src/main/java/org/stjs/generator/SyntheticClass.java
@@ -1,0 +1,83 @@
+package org.stjs.generator;
+
+import org.stjs.generator.name.DependencyType;
+import org.stjs.generator.utils.PreConditions;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class SyntheticClass implements ClassWithJavascript {
+	private final Class<?> clazz;
+	private final String jsNamespace;
+
+	public SyntheticClass(DependencyResolver dependencyResolver, Class<?> clazz) {
+		PreConditions.checkNotNull(dependencyResolver);
+		PreConditions.checkNotNull(clazz);
+		this.clazz = clazz;
+		String ns = NamespaceUtil.resolveNamespace(clazz);
+		if (ns == null) {
+			// If we can't find a namespace in the bridge stuff, then we have to assume
+			// there is no namespace
+			ns = "";
+		}
+		this.jsNamespace = ns;
+	}
+
+	@Override
+	public String getClassName() {
+		return clazz.getName();
+	}
+
+	@Override
+	public String getJavascriptNamespace() {
+		return this.jsNamespace;
+	}
+
+	@Override
+	public List<URI> getJavascriptFiles() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public List<ClassWithJavascript> getDirectDependencies() {
+		// TODO use annotations
+		return Collections.emptyList();
+	}
+
+	@Override
+	public Map<ClassWithJavascript, DependencyType> getDirectDependencyMap() {
+		// TODO use annotations
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + clazz.getName().hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		SyntheticClass other = (SyntheticClass) obj;
+
+		return clazz == other.clazz;
+	}
+
+	@Override
+	public String toString() {
+		return "SyntheticClass:" + clazz.getName();
+	}
+}

--- a/generator/src/main/java/org/stjs/generator/utils/ClassUtils.java
+++ b/generator/src/main/java/org/stjs/generator/utils/ClassUtils.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 
 import org.stjs.generator.JavascriptClassGenerationException;
 import org.stjs.javascript.annotation.STJSBridge;
+import org.stjs.javascript.annotation.SyntheticType;
 
 public final class ClassUtils {
 	/**
@@ -52,6 +53,11 @@ public final class ClassUtils {
 			return true;
 		}
 		return false;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static boolean isSynthetic(ClassLoader builtProjectClassLoader, Class<?> clazz) {
+		return hasAnnotation(clazz, (Class<? extends Annotation>) getClazz(builtProjectClassLoader, SyntheticType.class.getName()));
 	}
 
 	public static boolean hasAnnotation(Class<?> clazz, Class<? extends Annotation> annotationClass) {

--- a/generator/src/main/java/org/stjs/generator/visitor/TreePathScannerContributors.java
+++ b/generator/src/main/java/org/stjs/generator/visitor/TreePathScannerContributors.java
@@ -168,14 +168,14 @@ public class TreePathScannerContributors<R, P extends TreePathHolder, V extends 
 		return null;
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "unchecked", "PMD.UnusedFormalParameter" })
 	public <T extends Tree> R forward(DiscriminatorKey discriminator, T node, P param) {
 		VisitorContributor<? extends Tree, R, P, V> contributor = contributorsWithDiscriminator.get(discriminator);
 		if (contributor != null) {
 			// here i should be sure i have the right type
 			return ((VisitorContributor<T, R, P, V>) contributor).visit((V) this, node, param);
 		}
-		System.err.println("No contributor found with key:" + discriminator);
+		//System.err.println("No contributor found with key:" + discriminator);
 		return null;
 	}
 

--- a/generator/src/main/java/org/stjs/generator/writer/expression/MemberSelectWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/MemberSelectWriter.java
@@ -27,6 +27,7 @@ public class MemberSelectWriter<JS> implements WriterContributor<MemberSelectTre
 		return visitor.forward(DiscriminatorKey.of(MemberSelectWriter.class.getSimpleName(), templateName), tree, context);
 	}
 
+	@SuppressWarnings("PMD.UnusedFormalParameter")
 	private String buildTemplateName(MemberSelectTree tree, GenerationContext<JS> context) {
 		TreeWrapper<IdentifierTree, JS> tw = context.getCurrentWrapper();
 

--- a/generator/src/main/java/org/stjs/generator/writer/templates/fields/DefaultMemberSelectTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/fields/DefaultMemberSelectTemplate.java
@@ -51,8 +51,8 @@ public class DefaultMemberSelectTemplate<JS> implements WriterContributor<Member
 			// package names are ignored
 			return null;
 		}
-		if (element.getKind() == ElementKind.CLASS){
-			if(tw.isGlobal()) {
+		if (element.getKind() == ElementKind.CLASS) {
+			if (tw.isGlobal()) {
 				// global classes are ignored
 				return null;
 

--- a/generator/src/test/java/org/stjs/generator/writer/synthetic/Synthetic4.java
+++ b/generator/src/test/java/org/stjs/generator/writer/synthetic/Synthetic4.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.synthetic;
+
+import org.stjs.javascript.annotation.SyntheticType;
+
+@SyntheticType
+public class Synthetic4 {
+	public String name;
+}

--- a/generator/src/test/java/org/stjs/generator/writer/synthetic/SyntheticTypeGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/synthetic/SyntheticTypeGeneratorTest.java
@@ -21,4 +21,10 @@ public class SyntheticTypeGeneratorTest {
 	public void testAllowCallSuperMethod() {
 		assertCodeContains(Synthetic3.class, "method2=function(){this.method();}");
 	}
+
+	@Test(expected = IndexOutOfBoundsException.class)
+	public void testWillNotGenerate() {
+		// the class is a bridge so no code is actually generated
+		generate(Synthetic4.class);
+	}
 }


### PR DESCRIPTION
As presented in issue #70 Synthetic types are generated and can be found in the final code. this is not ideal.

this pull request fixes: Synthetic types will be treated as bridges.