### PR TITLE
Enable Travis-ci for ST-JS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+
+# Cache maven downloads
+sudo: false
+cache:
+  directories:
+    - $HOME/.m2
+
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+
+# Do this in install, as the normal way to do it, would
+# do a `mvn install` here. we want to do it all at once.
+install:
+  - export JAVA8_HOME=`jdk_switcher home oraclejdk8`
+  - echo $JAVA8_HOME
+
+script:
+  - mvn clean install -B -V

--- a/generator/src/main/java/org/stjs/generator/javac/PackageInternalsFinder.java
+++ b/generator/src/main/java/org/stjs/generator/javac/PackageInternalsFinder.java
@@ -22,9 +22,9 @@ import com.google.common.collect.Maps;
 
 /**
  * this class looks for packages in the classpath
- * 
+ *
  * @author acraciun
- * 
+ *
  */
 public class PackageInternalsFinder {
 	private final ClassLoader classLoader;
@@ -108,6 +108,8 @@ public class PackageInternalsFinder {
 		List<JavaFileObject> result = new ArrayList<JavaFileObject>();
 
 		File[] childFiles = directory.listFiles();
+		assert childFiles != null;
+
 		for (File childFile : childFiles) {
 			if (childFile.isFile() && childFile.getName().endsWith(CLASS_FILE_EXTENSION)) {
 				// We only want the .class files.

--- a/generator/src/main/java/org/stjs/generator/sourcemap/JavascriptToJava.java
+++ b/generator/src/main/java/org/stjs/generator/sourcemap/JavascriptToJava.java
@@ -20,6 +20,8 @@ import com.google.debugging.sourcemap.SourceMapConsumerFactory;
 import com.google.debugging.sourcemap.SourceMapParseException;
 import com.google.debugging.sourcemap.SourceMapping;
 
+import static java.lang.Integer.parseInt;
+
 public class JavascriptToJava {
 	private final static Pattern STACKTRACE_UNIVERSAL_JS_PATTERN = Pattern
 			.compile("\\s*(?:at)?\\s*(?:([\\w$]+)\\.)*(\\w*\\s?\\w+)[\\s\\@]?\\(?([^\\)]+)\\)?");
@@ -103,7 +105,7 @@ public class JavascriptToJava {
 
 			// java line
 			String cleanJsPath = url.getPath().split(":")[0];
-			int jsLineNumber = Integer.valueOf(fileParts[1]);
+			int jsLineNumber = parseInt(fileParts[1]);
 			int line = getJavaLine(cleanJsPath, jsLineNumber);
 			String stjsPropertyFile = cleanJsPath.replaceAll("\\.js$", ".stjs");
 

--- a/generator/src/main/java/org/stjs/generator/writer/expression/NewClassWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/NewClassWriter.java
@@ -113,9 +113,6 @@ public class NewClassWriter<JS> implements WriterContributor<NewClassTree, JS> {
 			JavaScriptBuilder<JS> js = tw.getContext().js();
 			JS target = js.keyword(Keyword.THIS);
 			JS stjsBind = js.property(js.name("stjs"), "bind");
-			if (specialThisParamPos < 0) {
-				return js.functionCall(stjsBind, Arrays.asList(target, func));
-			}
 			return js.functionCall(stjsBind, Arrays.asList(target, func, js.number(specialThisParamPos)));
 		}
 

--- a/generator/src/main/java/org/stjs/generator/writer/templates/PutTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/PutTemplate.java
@@ -10,7 +10,7 @@ import com.sun.source.tree.MethodInvocationTree;
 
 /**
  * array.$set(index, value) -> array[index] = value, or $set(obj, prop, value) -> obj[prop]=value
- * 
+ *
  * @author acraciun
  */
 public class PutTemplate<JS> implements WriterContributor<MethodInvocationTree, JS> {
@@ -19,7 +19,7 @@ public class PutTemplate<JS> implements WriterContributor<MethodInvocationTree, 
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, MethodInvocationTree tree, GenerationContext<JS> context) {
 		int argCount = tree.getArguments().size();
-		if (argCount < MIN_ARGS_COUNT && argCount > MIN_ARGS_COUNT + 1) {
+		if (argCount < MIN_ARGS_COUNT || argCount > MIN_ARGS_COUNT + 1) {
 			throw context.addError(tree, "A 'put' template can only be applied for methods with 2 or 3 parameters");
 		}
 

--- a/maven-plugin-it/src/test/resources/package-js-webjar/src/test/resources/stjs-test.properties
+++ b/maven-plugin-it/src/test/resources/package-js-webjar/src/test/resources/stjs-test.properties
@@ -1,6 +1,6 @@
 # stjs.test.port=8055
 # stjs.test.wait=10
-# stjs.test.testTimeout=15
+stjs.test.testTimeout=10
 # stjs.test.startBrowser=true
 # stjs.test.debug=true
 stjs.test.browsers=rhino

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<maven-scm-provider-svnexe.version>1.1</maven-scm-provider-svnexe.version>
 
 		<!-- code analysis plugins -->
-		<findbugs-maven-plugin.version>2.5.3</findbugs-maven-plugin.version>
+		<findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
 
 		<maven-pmd-plugin.version>3.0.1</maven-pmd-plugin.version>
 		<maven-checkstyle-plugin.version>2.10</maven-checkstyle-plugin.version>


### PR DESCRIPTION
Hi,

I added a travis configuration, for st-js.
I also fixed things that were not working in travis:
- findbugs failed on Java 8.
- when updating findbugs a few new warnings where thrown, these are also fixed here.
- the Rhino test executor failed too fast for travis, changed the threshold to 10seconds.

The configuration also contains a cache for the .m2 folder, this allows to not re-download the dependencies everytime.

Working build here : https://travis-ci.org/onigoetz/st-js/builds/60091045

If you accept this pull-request, you will have to go to travis-ci, log in with your github account and enable testing for st-js.