### PR TITLE
Add scripts inheritance in test-helper

### DIFF
--- a/test-helper/pom.xml
+++ b/test-helper/pom.xml
@@ -55,6 +55,12 @@
 			<version>2.21.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.10.19</version>
+		</dependency>
+
 	</dependencies>
 
 </project>

--- a/test-helper/src/main/java/org/stjs/testing/driver/TestClassAttributes.java
+++ b/test-helper/src/main/java/org/stjs/testing/driver/TestClassAttributes.java
@@ -1,6 +1,12 @@
 package org.stjs.testing.driver;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
@@ -9,6 +15,7 @@ import org.junit.runners.model.TestClass;
 import org.stjs.generator.ClassResolver;
 import org.stjs.generator.ClassWithJavascript;
 import org.stjs.generator.DependencyCollector;
+import org.stjs.javascript.functions.Function1;
 import org.stjs.testing.annotation.HTMLFixture;
 import org.stjs.testing.annotation.Scripts;
 import org.stjs.testing.annotation.ScriptsAfter;
@@ -21,36 +28,62 @@ public class TestClassAttributes {
 
 	private final HTMLFixture htmlFixture;
 
-	private final Scripts scripts;
-	private final ScriptsBefore scriptsBefore;
-	private final ScriptsAfter scriptsAfter;
+	private final List<String> scripts;
+	private final List<String> scriptsBefore;
+	private final List<String> scriptsAfter;
 
 	private final ClassWithJavascript stjsClass;
 	private final List<ClassWithJavascript> dependencies;
 
-	public TestClassAttributes(TestClass testClass, ClassResolver classResolver, DependencyCollector dependencyCollector){
+	public TestClassAttributes(TestClass testClass, ClassResolver classResolver, DependencyCollector dependencyCollector) {
 		beforeMethods = testClass.getAnnotatedMethods(Before.class);
 		afterMethods = testClass.getAnnotatedMethods(After.class);
 		stjsClass = classResolver.resolve(testClass.getName());
 
 		htmlFixture = testClass.getJavaClass().getAnnotation(HTMLFixture.class);
 
-		scripts = testClass.getJavaClass().getAnnotation(Scripts.class);
-		scriptsBefore = testClass.getJavaClass().getAnnotation(ScriptsBefore.class);
-		scriptsAfter = testClass.getJavaClass().getAnnotation(ScriptsAfter.class);
+		scripts = getScriptsPathes(testClass.getJavaClass(), Scripts.class, new Function1<Annotation, Collection<String>>() {
+			@Override
+			public Collection<String> $invoke(Annotation annotation) {
+				return Arrays.asList(Scripts.class.cast(annotation).value());
+			}
+		});
+
+		scriptsBefore = getScriptsPathes(testClass.getJavaClass(), ScriptsBefore.class, new Function1<Annotation, Collection<String>>() {
+			@Override
+			public Collection<String> $invoke(Annotation annotation) {
+				return Arrays.asList(ScriptsBefore.class.cast(annotation).value());
+			}
+		});
+
+		scriptsAfter = getScriptsPathes(testClass.getJavaClass(), ScriptsAfter.class, new Function1<Annotation, Collection<String>>() {
+			@Override
+			public Collection<String> $invoke(Annotation annotation) {
+				return Arrays.asList(ScriptsAfter.class.cast(annotation).value());
+			}
+		});
 
 		dependencies = dependencyCollector.orderAllDependencies(stjsClass);
 	}
 
-	public Scripts getScripts() {
+	/**
+	 * @return scripts pathes or empty list
+	 */
+	public List<String> getScripts() {
 		return scripts;
 	}
 
-	public ScriptsAfter getScriptsAfter() {
+	/**
+	 * @return scripts pathes or empty list
+	 */
+	public List<String> getScriptsAfter() {
 		return scriptsAfter;
 	}
 
-	public ScriptsBefore getScriptsBefore() {
+	/**
+	 * @return scripts pathes or empty list
+	 */
+	public List<String> getScriptsBefore() {
 		return scriptsBefore;
 	}
 
@@ -72,5 +105,27 @@ public class TestClassAttributes {
 
 	public ClassWithJavascript getStjsClass() {
 		return stjsClass;
+	}
+
+	private List<String> getScriptsPathes(Class clazz, Class<? extends Annotation> anotClazz, Function1<Annotation, Collection<String>> caster) {
+		List<Annotation> scriptsAnnots = accumulateAnnots(clazz, anotClazz, new ArrayList<Annotation>());
+		Set<String> scripts = new LinkedHashSet<>();
+		for (Annotation annotation : scriptsAnnots) {
+			scripts.addAll(caster.$invoke(annotation));
+		}
+
+		return new ArrayList<>(scripts);
+	}
+
+	private List<Annotation> accumulateAnnots(Class clazz, Class<? extends Annotation> annotation, List<Annotation> accum) {
+		if (Object.class.equals(clazz)) {
+			return accum;
+		} else {
+			Annotation annot = clazz.getAnnotation(annotation);
+			if (annot != null) {
+				accum.add(annot);
+			}
+			return accumulateAnnots(clazz.getSuperclass(), annotation, accum);
+		}
 	}
 }

--- a/test-helper/src/main/java/org/stjs/testing/driver/browser/LongPollingBrowser.java
+++ b/test-helper/src/main/java/org/stjs/testing/driver/browser/LongPollingBrowser.java
@@ -214,22 +214,18 @@ public abstract class LongPollingBrowser extends AbstractBrowser {
 		resp.append("<script language='javascript'>stjs.mainCallDisabled=true;</script>\n");
 
 		// scripts added explicitly
-		if (attr.getScripts() != null) {
-			for (String script : attr.getScripts().value()) {
-				appendScriptTag(resp, script);
-			}
+		for (String script : attr.getScripts()) {
+			appendScriptTag(resp, script);
 		}
 		// scripts before - new style
-		if (attr.getScriptsBefore() != null) {
-			for (String script : attr.getScriptsBefore().value()) {
-				appendScriptTag(resp, script);
-			}
+		for (String script : attr.getScriptsBefore()) {
+			appendScriptTag(resp, script);
 		}
 
 		Set<URI> jsFiles = new LinkedHashSet<>();
 		for (ClassWithJavascript dep : attr.getDependencies()) {
 
-			if (attr.getScripts() != null && dep instanceof BridgeClass) {
+			if (!attr.getScripts().isEmpty() && dep instanceof BridgeClass) {
 				// bridge dependencies are not added when using @Scripts
 				System.out.println(
 						"WARNING: You're using @Scripts deprecated annotation that disables the automatic inclusion of the Javascript files of the bridges you're using! "
@@ -246,11 +242,10 @@ public abstract class LongPollingBrowser extends AbstractBrowser {
 		}
 
 		// scripts after - new style
-		if (attr.getScriptsAfter() != null) {
-			for (String script : attr.getScriptsAfter().value()) {
-				appendScriptTag(resp, script);
-			}
+		for (String script : attr.getScriptsAfter()) {
+			appendScriptTag(resp, script);
 		}
+
 		resp.append("<script language='javascript'>\n");
 		resp.append("  window.onload=function(){\n");
 		// resp.append("    console.error(document.getElementsByTagName('html')[0].innerHTML);\n");

--- a/test-helper/src/test/java/org/stjs/testing/driver/TestClassAttributesTest.java
+++ b/test-helper/src/test/java/org/stjs/testing/driver/TestClassAttributesTest.java
@@ -1,0 +1,201 @@
+package org.stjs.testing.driver;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.model.TestClass;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.stjs.generator.ClassResolver;
+import org.stjs.generator.DependencyCollector;
+import org.stjs.testing.annotation.Scripts;
+import org.stjs.testing.annotation.ScriptsAfter;
+import org.stjs.testing.annotation.ScriptsBefore;
+
+/**
+ * Created by diermiichuk on 7/2/15.
+ */
+public class TestClassAttributesTest {
+
+	private static final String PARENT_SCRIPT_1 = "classpath://js/parent1.js";
+	private static final String PARENT_SCRIPT_2 = "classpath://js/parent2.js";
+	private static final String PARENT_SCRIPT_BEFORE_1 = "classpath://js/parentBefore1.js";
+	private static final String PARENT_SCRIPT_BEFORE_2 = "classpath://js/parentBefore2.js";
+	private static final String PARENT_SCRIPT_AFTER_1 = "classpath://js/parentAfter1.js";
+	private static final String PARENT_SCRIPT_AFTER_2 = "classpath://js/parentAfter2.js";
+
+	private static final String CHILD_SCRIPT_1 = "classpath://js/child1.js";
+	private static final String CHILD_SCRIPT_2 = "classpath://js/child2.js";
+	private static final String CHILD_SCRIPT_BEFORE_1 = "classpath://js/childBefore1.js";
+	private static final String CHILD_SCRIPT_BEFORE_2 = "classpath://js/childBefore2.js";
+	private static final String CHILD_SCRIPT_AFTER_1 = "classpath://js/childAfter1.js";
+	private static final String CHILD_SCRIPT_AFTER_2 = "classpath://js/childAfter2.js";
+
+	@Mock
+	ClassResolver classResolver;
+
+	@Mock
+	DependencyCollector dependencyCollector;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testAnnotationWithNoInheritance() throws ClassNotFoundException {
+
+		TestClass testClass = new TestClass(Parent.class);
+
+		TestClassAttributes testClassAttributes  = new TestClassAttributes(testClass, classResolver, dependencyCollector);
+
+		List<String> expectedScripts = Arrays.asList(PARENT_SCRIPT_1, PARENT_SCRIPT_2);
+		List<String> expectedBefore = Arrays.asList(PARENT_SCRIPT_BEFORE_1, PARENT_SCRIPT_BEFORE_2);
+		List<String> expectedAfter = Arrays.asList(PARENT_SCRIPT_AFTER_1, PARENT_SCRIPT_AFTER_2);
+
+		Assert.assertEquals(expectedScripts.size(), testClassAttributes.getScripts().size());
+		Assert.assertEquals(expectedBefore.size(), testClassAttributes.getScriptsBefore().size());
+		Assert.assertEquals(expectedAfter.size(), testClassAttributes.getScriptsAfter().size());
+
+		for (String script : testClassAttributes.getScripts()) {
+			Assert.assertTrue(expectedScripts.contains(script));
+		}
+
+		for (String script : testClassAttributes.getScriptsBefore()) {
+			Assert.assertTrue(expectedBefore.contains(script));
+		}
+
+		for (String script : testClassAttributes.getScriptsAfter()) {
+			Assert.assertTrue(expectedAfter.contains(script));
+		}
+	}
+
+	@Test
+	public void testAnnotationWithInheritance() {
+		TestClass testClass = new TestClass(Child.class);
+		TestClassAttributes testClassAttributes  = new TestClassAttributes(testClass, classResolver, dependencyCollector);
+
+		List<String> expectedScripts = Arrays.asList(PARENT_SCRIPT_1, PARENT_SCRIPT_2, CHILD_SCRIPT_1, CHILD_SCRIPT_2);
+		List<String> expectedBefore = Arrays.asList(PARENT_SCRIPT_BEFORE_1, PARENT_SCRIPT_BEFORE_2, CHILD_SCRIPT_BEFORE_1, CHILD_SCRIPT_BEFORE_2);
+		List<String> expectedAfter = Arrays.asList(PARENT_SCRIPT_AFTER_1, PARENT_SCRIPT_AFTER_2, CHILD_SCRIPT_AFTER_1, CHILD_SCRIPT_AFTER_2);
+
+		Assert.assertEquals(expectedScripts.size(), testClassAttributes.getScripts().size());
+		Assert.assertEquals(expectedBefore.size(), testClassAttributes.getScriptsBefore().size());
+		Assert.assertEquals(expectedAfter.size(), testClassAttributes.getScriptsAfter().size());
+
+		for (String script : testClassAttributes.getScripts()) {
+			Assert.assertTrue(expectedScripts.contains(script));
+		}
+
+		for (String script : testClassAttributes.getScriptsBefore()) {
+			Assert.assertTrue(expectedBefore.contains(script));
+		}
+
+		for (String script : testClassAttributes.getScriptsAfter()) {
+			Assert.assertTrue(expectedAfter.contains(script));
+		}
+	}
+
+	@Test
+	public void testAnnotationOrderWithInheritance() {
+		TestClass testClass = new TestClass(Child.class);
+		TestClassAttributes testClassAttributes  = new TestClassAttributes(testClass, classResolver, dependencyCollector);
+
+		List<String> expectedScripts = Arrays.asList(CHILD_SCRIPT_1, CHILD_SCRIPT_2, PARENT_SCRIPT_1, PARENT_SCRIPT_2);
+		List<String> expectedBefore = Arrays.asList(CHILD_SCRIPT_BEFORE_1, CHILD_SCRIPT_BEFORE_2, PARENT_SCRIPT_BEFORE_1, PARENT_SCRIPT_BEFORE_2);
+		List<String> expectedAfter = Arrays.asList(CHILD_SCRIPT_AFTER_1, CHILD_SCRIPT_AFTER_2, PARENT_SCRIPT_AFTER_1, PARENT_SCRIPT_AFTER_2);
+
+		Assert.assertEquals(expectedScripts.size(), testClassAttributes.getScripts().size());
+		Assert.assertEquals(expectedBefore.size(), testClassAttributes.getScriptsBefore().size());
+		Assert.assertEquals(expectedAfter.size(), testClassAttributes.getScriptsAfter().size());
+
+		for (int i = 0; i < 4; i++) {
+			Assert.assertEquals(expectedScripts.get(i), testClassAttributes.getScripts().get(i));
+			Assert.assertEquals(expectedBefore.get(i), testClassAttributes.getScriptsBefore().get(i));
+			Assert.assertEquals(expectedAfter.get(i), testClassAttributes.getScriptsAfter().get(i));
+		}
+	}
+
+
+	@Test
+	public void testAnnotationOverridingOrderWithInheritance() {
+		TestClass testClass = new TestClass(ChildWithSameScripts.class);
+		TestClassAttributes testClassAttributes  = new TestClassAttributes(testClass, classResolver, dependencyCollector);
+
+		List<String> expectedScripts = Arrays.asList(CHILD_SCRIPT_1, PARENT_SCRIPT_2, PARENT_SCRIPT_1);
+		List<String> expectedBefore = Arrays.asList(CHILD_SCRIPT_BEFORE_1, PARENT_SCRIPT_BEFORE_2, PARENT_SCRIPT_BEFORE_1);
+		List<String> expectedAfter = Arrays.asList(CHILD_SCRIPT_AFTER_1, PARENT_SCRIPT_AFTER_2, PARENT_SCRIPT_AFTER_1);
+
+		Assert.assertEquals(expectedScripts.size(), testClassAttributes.getScripts().size());
+		Assert.assertEquals(expectedBefore.size(), testClassAttributes.getScriptsBefore().size());
+		Assert.assertEquals(expectedAfter.size(), testClassAttributes.getScriptsAfter().size());
+
+		for (int i = 0; i < 3; i++) {
+			Assert.assertEquals(expectedScripts.get(i), testClassAttributes.getScripts().get(i));
+			Assert.assertEquals(expectedBefore.get(i), testClassAttributes.getScriptsBefore().get(i));
+			Assert.assertEquals(expectedAfter.get(i), testClassAttributes.getScriptsAfter().get(i));
+		}
+	}
+
+	@Test
+	public void testAnnotationOverridingOrderWithThreeLevenInherit() {
+		TestClass testClass = new TestClass(Son.class);
+		TestClassAttributes testClassAttributes  = new TestClassAttributes(testClass, classResolver, dependencyCollector);
+
+		List<String> expectedScripts = Arrays.asList(PARENT_SCRIPT_2, CHILD_SCRIPT_1, PARENT_SCRIPT_1);
+		List<String> expectedBefore = Arrays.asList(CHILD_SCRIPT_BEFORE_1, CHILD_SCRIPT_BEFORE_2, PARENT_SCRIPT_BEFORE_2, PARENT_SCRIPT_BEFORE_1);
+		List<String> expectedAfter = Arrays.asList(CHILD_SCRIPT_AFTER_1, CHILD_SCRIPT_AFTER_2, PARENT_SCRIPT_AFTER_2, PARENT_SCRIPT_AFTER_1);
+
+		Assert.assertEquals(expectedScripts.size(), testClassAttributes.getScripts().size());
+		Assert.assertEquals(expectedBefore.size(), testClassAttributes.getScriptsBefore().size());
+		Assert.assertEquals(expectedAfter.size(), testClassAttributes.getScriptsAfter().size());
+
+		for (int i = 0; i < expectedBefore.size(); i++) {
+			Assert.assertEquals(expectedBefore.get(i), testClassAttributes.getScriptsBefore().get(i));
+			Assert.assertEquals(expectedAfter.get(i), testClassAttributes.getScriptsAfter().get(i));
+		}
+
+		for (int i = 0; i < expectedScripts.size(); i++) {
+			Assert.assertEquals(expectedScripts.get(i), testClassAttributes.getScripts().get(i));
+		}
+	}
+
+	@Scripts({PARENT_SCRIPT_1, PARENT_SCRIPT_2})
+	@ScriptsBefore({PARENT_SCRIPT_BEFORE_1, PARENT_SCRIPT_BEFORE_2})
+	@ScriptsAfter({PARENT_SCRIPT_AFTER_1, PARENT_SCRIPT_AFTER_2})
+	class Parent {}
+
+	@Scripts({CHILD_SCRIPT_1, CHILD_SCRIPT_2})
+	@ScriptsBefore({CHILD_SCRIPT_BEFORE_1, CHILD_SCRIPT_BEFORE_2})
+	@ScriptsAfter({CHILD_SCRIPT_AFTER_1, CHILD_SCRIPT_AFTER_2})
+	class Child extends Parent {}
+
+
+	@Scripts({PARENT_SCRIPT_2, PARENT_SCRIPT_1})
+	@ScriptsBefore({PARENT_SCRIPT_BEFORE_2, PARENT_SCRIPT_BEFORE_1})
+	@ScriptsAfter({PARENT_SCRIPT_AFTER_2, PARENT_SCRIPT_AFTER_1})
+	class ParentWithSameScripts {}
+
+	@Scripts({CHILD_SCRIPT_1, PARENT_SCRIPT_2})
+	@ScriptsBefore({CHILD_SCRIPT_BEFORE_1, PARENT_SCRIPT_BEFORE_2})
+	@ScriptsAfter({CHILD_SCRIPT_AFTER_1, PARENT_SCRIPT_AFTER_2})
+	class ChildWithSameScripts extends ParentWithSameScripts {}
+
+	@Scripts({PARENT_SCRIPT_1})
+	@ScriptsBefore({PARENT_SCRIPT_BEFORE_1})
+	@ScriptsAfter({PARENT_SCRIPT_AFTER_1})
+	class Grandpa {}
+
+	@Scripts({PARENT_SCRIPT_2, CHILD_SCRIPT_1})
+	@ScriptsBefore({PARENT_SCRIPT_BEFORE_2, CHILD_SCRIPT_BEFORE_1})
+	@ScriptsAfter({PARENT_SCRIPT_AFTER_2, CHILD_SCRIPT_AFTER_1})
+	class Father extends Grandpa {}
+
+	@Scripts({})
+	@ScriptsBefore({CHILD_SCRIPT_BEFORE_1, CHILD_SCRIPT_BEFORE_2})
+	@ScriptsAfter({CHILD_SCRIPT_AFTER_1, CHILD_SCRIPT_AFTER_2})
+	class Son extends Father {}
+}


### PR DESCRIPTION
Add @Scripts, @ScriptsAfter and @ScriptsBefore annotation accumulation in case we have tests classes inheritance. Current implementation preserve scripts order.