### PR TITLE
Do not check for single arguments when using varargs on native methods

### DIFF
--- a/generator/src/main/java/org/stjs/generator/check/declaration/MethodVarArgParamCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/MethodVarArgParamCheck.java
@@ -30,6 +30,12 @@ public class MethodVarArgParamCheck implements CheckContributor<MethodTree> {
 		if (MemberWriters.shouldSkip(tw)) {
 			return null;
 		}
+
+		// Native methods can be safely ignored
+		if (tw.isNative()) {
+			return null;
+		}
+
 		for (VariableTree param : tree.getParameters()) {
 			if (InternalUtils.isVarArg(param)) {
 				checkVarArg(tree, param, context);

--- a/generator/src/test/java/org/stjs/generator/writer/methods/Methods11_b.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/Methods11_b.java
@@ -1,0 +1,11 @@
+package org.stjs.generator.writer.methods;
+
+import org.stjs.javascript.Map;
+
+public class Methods11_b {
+
+	public void test(Map<String, Object> props) {
+	}
+
+	public native void method(Map<String, Object> props, Object... args);
+}

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -80,6 +80,13 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 	}
 
 	@Test
+	public void testVarArgsMethod4Native() {
+		assertCodeContains(Methods11_b.class, "prototype.test=function(props){}");
+
+		assertCodeDoesNotContain(Methods11_b.class, "prototype.method=function");
+	}
+
+	@Test
 	public void testInterfaceImplResolution() {
 		assertCodeContains(Methods12.class, "method(c);");
 	}


### PR DESCRIPTION
Hi,

When I try to do a method with the following signature: 

```java
	public static native ReactElement<?> tspan(Map<String, Object> properties);
	public static native ReactElement<?> tspan(Map<String, Object> properties, Object... arguments);
```

I get `You can only have a vararg parameter that has to be called 'arguments'`

The methods here are auto-generated in the class' `main` method, so it is not a bridge.

With this pull request, the check for a single argument is not made on native methods, allowing this kind of signatures