### PR TITLE
Upgrade to guava v18

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>18.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Because the dependency 'com.google.javascript:closure-compiler:v20141215' requires Guava v18

Some deprecated methods were removed from Guava v18. Those methods were used to copy the "stjs.js" file to the output directory.

I'm using the gradle plugin from `https://github.com/dzwicker/st-js-gradle-plugin` and I was having problems resolving dependency versions conflicts since they've removed methods in Guava v18. 