### PR TITLE
Support for Java's "for each" with Iterable interface

### DIFF
--- a/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
@@ -142,6 +142,8 @@ public class GeneratorConfigurationBuilder {
 		allowedJavaLangClasses.add("Exception");
 		allowedJavaLangClasses.add("RuntimeException");
 
+		allowedJavaLangClasses.add("Iterable");
+
 		allowedPackages.add("java.lang");
 
 		return new GeneratorConfiguration(//

--- a/generator/src/test/java/org/stjs/generator/writer/statements/Statements22_ForEachIterable.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/Statements22_ForEachIterable.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.statements;
+
+public class Statements22_ForEachIterable {
+    public static void main(Iterable<String> myStringList) {
+        for (String oneOfTheString : myStringList) {
+        }
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -86,6 +86,11 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 	}
 
 	@Test
+	public void testForEachInWithIterable() {
+		assertCodeContains(Statements22_ForEachIterable.class, "for (var iterator$oneOfTheString = myStringList.iterator(); iterator$oneOfTheString.hasNext(); ) { var oneOfTheString = iterator$oneOfTheString.next(); }");
+	}
+
+	@Test
 	public void testForEachArrayBlock() {
 		assertCodeContains(Statements12.class, "if (!(a).hasOwnProperty(i)) continue;var x");
 	}


### PR DESCRIPTION
Support of Java's "for each" with Iterable.

The following Java code:
```java
void anyFunc(List<String> myStringList) {    
    for (String oneOfTheString : myStringList) {
        // do whatever you want with 'oneOfTheString'
    }
}
```

Will be converted in Javascript to:

```javascript
for (var iterator$oneOfTheString = myStringList.iterator(); iterator$oneOfTheString.hasNext(); ) {
    var oneOfTheString = iterator$oneOfTheString.next()
    // do whatever you want with 'oneOfTheString'
}
```
