### PR TITLE
Fix Number.prototype.isNaN returning incorrect value

### DIFF
--- a/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
+++ b/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
@@ -225,7 +225,9 @@ if (!Number.isNaN) {
 }
 
 if (!Number.prototype.isNaN) {
-	Number.prototype.isNaN = isNaN;
+	Number.prototype.isNaN = function() {
+		return isNaN(this);
+	}
 }
 if (!Number.prototype.equals) {
 	Number.prototype.equals=JavalikeEquals;


### PR DESCRIPTION
`isNaN` takes an argument and the way it was called before was basically always doing `isNaN()` which was always returning `true`