### PR TITLE
Fix hydrate exception when object has inner classes

### DIFF
--- a/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
+++ b/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
@@ -831,9 +831,13 @@ stjs.typefy=function(obj, cls){
 			  continue;
 		  }
 		  if (typeof prop == "string")
-			  ret[key] = convert(td, prop);
-		  else if (typeof prop == "object")
-			  ret[key] = stjs.typefy(prop, td);
+			ret[key] = convert(td, prop);
+		  else if (typeof prop == "object") {
+				if (typeof td == "string") {
+					td = eval(td);
+		  		}
+				ret[key] = stjs.typefy(prop, td);
+			}
 	  }
 	  return ret;
 };


### PR DESCRIPTION
Fix exception when typefy method tries to create an object calling string instead of constructor.