### PR TITLE
Primitives and Arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,130 @@ Compiling the Project
 ST-JS compiles with the traditional mvn install command, but it currently needs both Java 6 - that is the default JDK on the command line when you call the Maven command,
 but also Java 8 to compile the generator-plugin-java8 artifact. To achieve this, you need to to configure the environment variable JAVA8_HOME that points to the home of your JDK 8 home folder.
 
+## Notes on Primitives+Arrays Support
+
+### Arrays
+
+`AnyNonPrimitiveType[]` is `Array`
+
+```java
+String[] a = {"a", "b"};
+```
+
+```javascript
+var a = ["a", "b"];
+```
+
+### Multidimensional arrays
+
+```java
+float[][][] arr = new float[1][2][3];
+Object[][][] objarr = new Object[][][]{ new String[][]{ { "hello" }, { "world" }, new String[]{} }, new Integer[][]{ { 1, 2 }, { 3, 4 } }, new Double[4][5] };
+```
+
+```javascript
+var arr = Array.apply(null, Array(1)).map(function(){return Array.apply(null, Array(2)).map(function(){return new Float32Array(3);});});"
+var objarr = [[["hello"], ["world"], []], [[1, 2], [3, 4]], Array.apply(null, Array(4)).map(function() { return Array(5);})];
+```
+
+### Primitive Arrays
+
+| Java        | JavaScript     | 
+| ----------- | -------------- | 
+| `boolean[]` | `Int8Array`    | 
+| `byte[]`    | `Int8Array`    | 
+| `short[]`   | `Int16Array`   |
+| `char[]`    | `Uint16Array`  |
+| `int[]`     | `Int32Array`   |
+| `float[]`   | `Float32Array` |
+| `double[]`  | `Float64Array` |
+| `long[]`    | `Array`        |
+
+### `long`
+
+There is no support for 64bit integer type in JavaScript. Max value for an integer is 2^53-1
+```
+> Number.MAX_SAFE_INTEGER
+9007199254740991
+```
+
+### `char`
+
+`char` is stored in Java as `unsigned short` so it is in st-js primitive support.
+
+`char[]` in st-js is `Uint16Array`.
+
+The following side effects appear:
+
+```java
+String a = "hello worl";
+char c = 'd';
+String result = a + c;
+```
+
+```javascript
+var a = "hello worl";
+var c = 'd'.charCodeAt(0); //looks ugly but compatible
+var result = a + String.fromCharCode(c);
+```
+
+```java
+char c = 'a';
+byte b = (byte) c;
+```
+
+```javascript
+var c = 'a'.charCodeAt(0);
+var b = c << 24 >> 24;
+```
+
+### `float` and `double`
+
+Are considered equivalent no attempt for Java compatibility is made.
+
+### primitive type casting
+
+| Java            | JavaScript      | 
+| --------------- | --------------- | 
+| int to short    | `((i)<<16>>16)` | 
+| int to byte     | `((i)<<24>>24)` | 
+| int to char     | `((i)&0xfff)`   |
+| int to long     | `var l = i`     |
+| int to float    | `var f = i`     |
+| int to double   | `var d = i`     |
+| short to byte   | `((s)<<24>>24)` | 
+| short to char   | `((s)&0xfff)`   |
+| short to int    | `var i = s`     |
+| short to long   | `var l = s`     |
+| short to float  | `var f = s`     |
+| short to double | `var d = s`     |
+| byte to short   | `var s = b`     | 
+| byte to char    | `var c = b`     |
+| byte to int     | `var i = b`     |
+| byte to long    | `var l = b`     |
+| byte to float   | `var f = b`     |
+| byte to double  | `var d = b`     |
+| char to byte    | `((c)<<24>>24)` | 
+| char to short   | `var s = c`     | 
+| char to int     | `var i = c`     |
+| char to long    | `var l = c`     |
+| char to float   | `var f = c`     |
+| char to double  | `var d = c`     |
+| long to byte    | `((l)<<24>>24)` | 
+| long to short   | `((l)<<16>>16)` | 
+| long to char    | `((l)&0xfff)`   |
+| long to int     | `var i = l|0`   |
+| long to float   | `var f = l`     |
+| long to double  | `var d = l`     |
+| float to byte   | `((f)<<24>>24)` | 
+| float to short  | `((f)<<16>>16)` | 
+| float to char   | `((f)&0xfff)`   |
+| float to int    | `var i = f|0`   |
+| float to long   | `var l = f`     |
+| float to double | `var d = f`     |
+| double to byte  | `((d)<<24>>24)` | 
+| double to short | `((d)<<16>>16)` | 
+| double to char  | `((d)&0xfff)`   |
+| double to int   | `var i = d|0`   |
+| double to long  | `var l = d`     |
+| double to float | `var f = d`     |

--- a/README.md
+++ b/README.md
@@ -55,16 +55,16 @@ var objarr = [[["hello"], ["world"], []], [[1, 2], [3, 4]], Array.apply(null, Ar
 
 Enhanced for loop over Java arrays will iterate over values instead of keys
 ```java
-String[] arr = {"hello", "world"};
-for(String s : arr) {
+String[] msg = {"hello", "world"};
+for(String s : msg) {
 	console.log(s);
 }
 ```
 
 ```javascript
-var arr = ["hello", "world"];
-for(var index$arr = 0; index$arr < arr.length; index$arr++) {
-	var s = arr[index$arr];
+var msg = ["hello", "world"];
+for(var index$s = 0, arr$s = msg; index$s < arr$s.length; index$s++) {
+	var s = arr$s[index$s];
 	console.log(s);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ String[] arr = {"hello", "world"};
 for(String s : arr) {
 	console.log(s);
 }
+```
 
 ```javascript
 var arr = ["hello", "world"];

--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ var objarr = [[["hello"], ["world"], []], [[1, 2], [3, 4]], Array.apply(null, Ar
 | `double[]`  | `Float64Array` |
 | `long[]`    | `Array`        |
 
+### Foreach 
+
+Enhanced for loop over Java arrays will iterate over values instead of keys
+```java
+String[] arr = {"hello", "world"};
+for(String s : arr) {
+	console.log(s);
+}
+
+```javascript
+var arr = ["hello", "world"];
+for(var index$arr = 0; index$arr < arr.length; index$arr++) {
+	var s = arr[index$arr];
+	console.log(s);
+}
+```
+
 ### `long`
 
 There is no support for 64bit integer type in JavaScript. Max value for an integer is 2^53-1

--- a/generator/src/main/java/org/stjs/generator/check/declaration/ArrayTypeForbiddenCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/ArrayTypeForbiddenCheck.java
@@ -3,15 +3,8 @@ package org.stjs.generator.check.declaration;
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.check.CheckContributor;
 import org.stjs.generator.check.CheckVisitor;
-import org.stjs.generator.javac.InternalUtils;
-import org.stjs.generator.writer.declaration.ClassWriter;
 
 import com.sun.source.tree.ArrayTypeTree;
-import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.PrimitiveTypeTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.VariableTree;
-import com.sun.source.util.TreePath;
 
 /**
  * this class checks that you don't use java arrays in the code (the only exception is the main method - but maybe this
@@ -23,46 +16,7 @@ public class ArrayTypeForbiddenCheck implements CheckContributor<ArrayTypeTree> 
 
 	@Override
 	public Void visit(CheckVisitor visitor, ArrayTypeTree tree, GenerationContext<Void> context) {
-		if (!argOfMainMethod(context) && !isVarArg(context) && !isPrimitiveArray(tree)) {
-			context.addError(tree,
-					"You cannot use Java arrays because they are incompatible with Javascript arrays. "
-							+ "Use org.stjs.javascript.Array<T> instead. "
-							+ "You can use also the method org.stjs.javascript.Global.$castArray to convert an "
-							+ "existent Java array to the corresponding Array type." + "The only exception is void main(String[] args).");
-		}
 		return null;
-	}
-
-	private boolean isPrimitiveArray(ArrayTypeTree tree) {
-		Tree type = tree.getType();
-		while (type instanceof ArrayTypeTree) {
-			type = ((ArrayTypeTree) type).getType();
-		}
-		return (type instanceof PrimitiveTypeTree);
-	}
-
-	private boolean isVarArg(GenerationContext<Void> context) {
-		TreePath path = context.getCurrentPath();
-		if (!(path.getParentPath().getLeaf() instanceof VariableTree)) {
-			return false;
-		}
-		return InternalUtils.isVarArg(path.getParentPath().getLeaf());
-	}
-
-	private boolean argOfMainMethod(GenerationContext<Void> context) {
-		TreePath path = context.getCurrentPath();
-		if (!(path.getParentPath().getLeaf() instanceof VariableTree)) {
-			return false;
-		}
-		if (!(path.getParentPath().getParentPath().getLeaf() instanceof MethodTree)) {
-			return false;
-		}
-		MethodTree method = (MethodTree) path.getParentPath().getParentPath().getLeaf();
-		if (!(method.getParameters().size() == 1 && method.getParameters().get(0) == path.getParentPath().getLeaf())) {
-			// make sure we reference the first parameter
-			return false;
-		}
-		return ClassWriter.isMainMethod(method);
 	}
 
 }

--- a/generator/src/main/java/org/stjs/generator/check/declaration/ArrayTypeForbiddenCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/ArrayTypeForbiddenCheck.java
@@ -8,6 +8,8 @@ import org.stjs.generator.writer.declaration.ClassWriter;
 
 import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.PrimitiveTypeTree;
+import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 
@@ -21,13 +23,22 @@ public class ArrayTypeForbiddenCheck implements CheckContributor<ArrayTypeTree> 
 
 	@Override
 	public Void visit(CheckVisitor visitor, ArrayTypeTree tree, GenerationContext<Void> context) {
-		if (!argOfMainMethod(context) && !isVarArg(context)) {
-			context.addError(tree, "You cannot use Java arrays because they are incompatible with Javascript arrays. "
-					+ "Use org.stjs.javascript.Array<T> instead. "
-					+ "You can use also the method org.stjs.javascript.Global.$castArray to convert an "
-					+ "existent Java array to the corresponding Array type." + "The only exception is void main(String[] args).");
+		if (!argOfMainMethod(context) && !isVarArg(context) && !isPrimitiveArray(tree)) {
+			context.addError(tree,
+					"You cannot use Java arrays because they are incompatible with Javascript arrays. "
+							+ "Use org.stjs.javascript.Array<T> instead. "
+							+ "You can use also the method org.stjs.javascript.Global.$castArray to convert an "
+							+ "existent Java array to the corresponding Array type." + "The only exception is void main(String[] args).");
 		}
 		return null;
+	}
+
+	private boolean isPrimitiveArray(ArrayTypeTree tree) {
+		Tree type = tree.getType();
+		while (type instanceof ArrayTypeTree) {
+			type = ((ArrayTypeTree) type).getType();
+		}
+		return (type instanceof PrimitiveTypeTree);
 	}
 
 	private boolean isVarArg(GenerationContext<Void> context) {

--- a/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
@@ -1,17 +1,10 @@
 package org.stjs.generator.check.expression;
 
-import java.lang.reflect.Field;
-
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.check.CheckContributor;
 import org.stjs.generator.check.CheckVisitor;
 
-import com.sun.source.tree.AnnotationTree;
-import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.NewArrayTree;
-import com.sun.source.tree.PrimitiveTypeTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.util.TreePath;
 
 /**
  * this checks that no java array is used. You should use {@link org.stjs.javascript.Array} instead.
@@ -22,44 +15,6 @@ public class NewArrayForbiddenCheck implements CheckContributor<NewArrayTree> {
 
 	@Override
 	public Void visit(CheckVisitor visitor, NewArrayTree tree, GenerationContext<Void> context) {
-		if (isAnnotationParam(context.getCurrentPath()) || isPrimitive(tree)) {
-			return null;
-		}
-		context.addError(tree,
-				"You cannot use Java arrays because they are incompatible with Javascript arrays. "
-						+ "Use org.stjs.javascript.Array<T> instead. "
-						+ "You can use also the method org.stjs.javascript.Global.$castArray to convert an "
-						+ "existent Java array to the corresponding Array type." + "The only exception is void main(String[] args).");
-
 		return null;
 	}
-
-	private boolean isPrimitive(NewArrayTree tree) {
-		Tree type = tree.getType();
-		if (type == null || type instanceof ArrayTypeTree) {
-			try {
-				Field field = tree.getClass().getField("type");
-				Object ftype = field.get(tree);
-				while (ftype instanceof com.sun.tools.javac.code.Type.ArrayType) {
-					com.sun.tools.javac.code.Type.ArrayType atype = (com.sun.tools.javac.code.Type.ArrayType) ftype;
-					com.sun.tools.javac.code.Type elemtype2 = atype.elemtype;
-					boolean primitive = elemtype2.isPrimitive();
-					if (primitive) {
-						return primitive;
-					} else {
-						ftype = elemtype2;
-					}
-				}
-			}
-			catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-				return false;
-			}
-		}
-		return type instanceof PrimitiveTypeTree;
-	}
-
-	private boolean isAnnotationParam(TreePath currentPath) {
-		return currentPath.getParentPath().getParentPath().getLeaf() instanceof AnnotationTree;
-	}
-
 }

--- a/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
@@ -7,6 +7,7 @@ import org.stjs.generator.check.CheckContributor;
 import org.stjs.generator.check.CheckVisitor;
 
 import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.PrimitiveTypeTree;
 import com.sun.source.tree.Tree;
@@ -35,7 +36,7 @@ public class NewArrayForbiddenCheck implements CheckContributor<NewArrayTree> {
 
 	private boolean isPrimitive(NewArrayTree tree) {
 		Tree type = tree.getType();
-		if (type == null) {
+		if (type == null || type instanceof ArrayTypeTree) {
 			try {
 				Field field = tree.getClass().getField("type");
 				Object ftype = field.get(tree);
@@ -53,7 +54,6 @@ public class NewArrayForbiddenCheck implements CheckContributor<NewArrayTree> {
 			catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
 				return false;
 			}
-
 		}
 		return type instanceof PrimitiveTypeTree;
 	}

--- a/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
@@ -10,10 +10,7 @@ import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.PrimitiveTypeTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
-import com.sun.tools.classfile.Type;
-import com.sun.tools.classfile.Type.ArrayType;
 
 /**
  * this checks that no java array is used. You should use {@link org.stjs.javascript.Array} instead.
@@ -41,15 +38,15 @@ public class NewArrayForbiddenCheck implements CheckContributor<NewArrayTree> {
 		if (type == null) {
 			try {
 				Field field = tree.getClass().getField("type");
-				Object _type = field.get(tree);
-				while (_type instanceof com.sun.tools.javac.code.Type.ArrayType) {
-					com.sun.tools.javac.code.Type.ArrayType atype = (com.sun.tools.javac.code.Type.ArrayType) _type;
+				Object ftype = field.get(tree);
+				while (ftype instanceof com.sun.tools.javac.code.Type.ArrayType) {
+					com.sun.tools.javac.code.Type.ArrayType atype = (com.sun.tools.javac.code.Type.ArrayType) ftype;
 					com.sun.tools.javac.code.Type elemtype2 = atype.elemtype;
 					boolean primitive = elemtype2.isPrimitive();
 					if (primitive) {
 						return primitive;
 					} else {
-						_type = elemtype2;
+						ftype = elemtype2;
 					}
 				}
 			}

--- a/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/expression/NewArrayForbiddenCheck.java
@@ -1,12 +1,19 @@
 package org.stjs.generator.check.expression;
 
+import java.lang.reflect.Field;
+
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.check.CheckContributor;
 import org.stjs.generator.check.CheckVisitor;
 
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.NewArrayTree;
+import com.sun.source.tree.PrimitiveTypeTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
+import com.sun.tools.classfile.Type;
+import com.sun.tools.classfile.Type.ArrayType;
 
 /**
  * this checks that no java array is used. You should use {@link org.stjs.javascript.Array} instead.
@@ -17,15 +24,41 @@ public class NewArrayForbiddenCheck implements CheckContributor<NewArrayTree> {
 
 	@Override
 	public Void visit(CheckVisitor visitor, NewArrayTree tree, GenerationContext<Void> context) {
-		if (isAnnotationParam(context.getCurrentPath())) {
+		if (isAnnotationParam(context.getCurrentPath()) || isPrimitive(tree)) {
 			return null;
 		}
-		context.addError(tree, "You cannot use Java arrays because they are incompatible with Javascript arrays. "
-				+ "Use org.stjs.javascript.Array<T> instead. "
-				+ "You can use also the method org.stjs.javascript.Global.$castArray to convert an "
-				+ "existent Java array to the corresponding Array type." + "The only exception is void main(String[] args).");
+		context.addError(tree,
+				"You cannot use Java arrays because they are incompatible with Javascript arrays. "
+						+ "Use org.stjs.javascript.Array<T> instead. "
+						+ "You can use also the method org.stjs.javascript.Global.$castArray to convert an "
+						+ "existent Java array to the corresponding Array type." + "The only exception is void main(String[] args).");
 
 		return null;
+	}
+
+	private boolean isPrimitive(NewArrayTree tree) {
+		Tree type = tree.getType();
+		if (type == null) {
+			try {
+				Field field = tree.getClass().getField("type");
+				Object _type = field.get(tree);
+				while (_type instanceof com.sun.tools.javac.code.Type.ArrayType) {
+					com.sun.tools.javac.code.Type.ArrayType atype = (com.sun.tools.javac.code.Type.ArrayType) _type;
+					com.sun.tools.javac.code.Type elemtype2 = atype.elemtype;
+					boolean primitive = elemtype2.isPrimitive();
+					if (primitive) {
+						return primitive;
+					} else {
+						_type = elemtype2;
+					}
+				}
+			}
+			catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+				return false;
+			}
+
+		}
+		return type instanceof PrimitiveTypeTree;
 	}
 
 	private boolean isAnnotationParam(TreePath currentPath) {

--- a/generator/src/main/java/org/stjs/generator/name/DefaultJavaScriptNameProvider.java
+++ b/generator/src/main/java/org/stjs/generator/name/DefaultJavaScriptNameProvider.java
@@ -3,7 +3,9 @@ package org.stjs.generator.name;
 import java.util.HashMap;
 import java.util.Map;
 import javax.lang.model.element.Element;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.WildcardType;
 
@@ -83,6 +85,29 @@ public class DefaultJavaScriptNameProvider implements JavaScriptNameProvider {
 			String fullName = addNameSpace(rootTypeElement, context, name);
 			resolvedTypes.put(type, new TypeInfo(fullName, rootTypeElement));
 			return fullName;
+		}
+		if (type instanceof ArrayType) {
+		    ArrayType atype = (ArrayType) type;
+		    TypeMirror componentType = atype.getComponentType();
+		    TypeKind kind = componentType.getKind();
+		    switch (kind) {
+            case BOOLEAN:
+                return "Int8Array";
+            case BYTE:
+                return "Int8Array";
+            case SHORT:
+                return "Int16Array";
+            case CHAR:
+                return "Uint16Array";
+            case INT:
+                return "Int32Array";
+            case FLOAT:
+                return "Float32Array";
+            case DOUBLE:
+                return "Float64Array";
+            default:
+                return "Array";
+            }
 		}
 		if (type instanceof WildcardType) {
 			// ? extends Type1 super Type2

--- a/generator/src/main/java/org/stjs/generator/name/DefaultJavaScriptNameProvider.java
+++ b/generator/src/main/java/org/stjs/generator/name/DefaultJavaScriptNameProvider.java
@@ -29,9 +29,19 @@ import com.sun.source.util.TreePath;
 public class DefaultJavaScriptNameProvider implements JavaScriptNameProvider {
 	private static final String JAVA_LANG_PACKAGE = "java.lang.";
 	private static final int JAVA_LANG_LENGTH = JAVA_LANG_PACKAGE.length();
-
+	private static final Map<TypeKind, String> JS_ARRAY_TYPES = new HashMap<>();
 	private final Map<String, DependencyType> resolvedRootTypes = new HashMap<String, DependencyType>();
 	private final Map<TypeMirror, TypeInfo> resolvedTypes = new HashMap<TypeMirror, TypeInfo>();
+
+	static {
+		JS_ARRAY_TYPES.put(TypeKind.BOOLEAN, "Int8Array");
+		JS_ARRAY_TYPES.put(TypeKind.BYTE, "Int8Array");
+		JS_ARRAY_TYPES.put(TypeKind.SHORT, "Int16Array");
+		JS_ARRAY_TYPES.put(TypeKind.CHAR, "Uint16Array");
+		JS_ARRAY_TYPES.put(TypeKind.INT, "Int32Array");
+		JS_ARRAY_TYPES.put(TypeKind.FLOAT, "Float32Array");
+		JS_ARRAY_TYPES.put(TypeKind.DOUBLE, "Float64Array");
+	}
 
 	private class TypeInfo {
 		private final String fullName;
@@ -87,27 +97,7 @@ public class DefaultJavaScriptNameProvider implements JavaScriptNameProvider {
 			return fullName;
 		}
 		if (type instanceof ArrayType) {
-		    ArrayType atype = (ArrayType) type;
-		    TypeMirror componentType = atype.getComponentType();
-		    TypeKind kind = componentType.getKind();
-		    switch (kind) {
-            case BOOLEAN:
-                return "Int8Array";
-            case BYTE:
-                return "Int8Array";
-            case SHORT:
-                return "Int16Array";
-            case CHAR:
-                return "Uint16Array";
-            case INT:
-                return "Int32Array";
-            case FLOAT:
-                return "Float32Array";
-            case DOUBLE:
-                return "Float64Array";
-            default:
-                return "Array";
-            }
+			return handleArrayType((ArrayType) type);
 		}
 		if (type instanceof WildcardType) {
 			// ? extends Type1 super Type2
@@ -115,6 +105,13 @@ public class DefaultJavaScriptNameProvider implements JavaScriptNameProvider {
 			return "Object";
 		}
 		return type.toString();
+	}
+
+	private static String handleArrayType(ArrayType atype) {
+		TypeMirror componentType = atype.getComponentType();
+		TypeKind kind = componentType.getKind();
+		String jsType = JS_ARRAY_TYPES.get(kind);
+		return jsType == null ? "Array" : jsType;
 	}
 
 	private void typeNotAllowedException(GenerationContext<?> context, String name) {

--- a/generator/src/main/java/org/stjs/generator/writer/expression/BinaryWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/BinaryWriter.java
@@ -1,39 +1,52 @@
 package org.stjs.generator.writer.expression;
 
+import static java.util.Arrays.asList;
+
 import java.util.Arrays;
 import java.util.Collections;
 
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.javac.TypesUtils;
 import org.stjs.generator.javascript.BinaryOperator;
+import org.stjs.generator.javascript.JavaScriptBuilder;
 import org.stjs.generator.writer.WriterContributor;
 import org.stjs.generator.writer.WriterVisitor;
 
 import com.sun.source.tree.BinaryTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
 
 public class BinaryWriter<JS> implements WriterContributor<BinaryTree, JS> {
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, BinaryTree tree, GenerationContext<JS> context) {
-		JS left = visitor.scan(tree.getLeftOperand(), context);
-		JS right = visitor.scan(tree.getRightOperand(), context);
+	    JS left = visitor.scan(tree.getLeftOperand(), context);
+        JS right = visitor.scan(tree.getRightOperand(), context);
 		BinaryOperator op = BinaryOperator.valueOf(tree.getKind());
 		assert op != null : "Unknow operator:" + tree.getKind();
 
-		@SuppressWarnings("unchecked")
-		JS expr = context.js().binary(op, Arrays.asList(left, right));
 
 		TypeMirror leftType = context.getTrees().getTypeMirror(new TreePath(context.getCurrentPath(), tree.getLeftOperand()));
 		TypeMirror rightType = context.getTrees().getTypeMirror(new TreePath(context.getCurrentPath(), tree.getRightOperand()));
+		JavaScriptBuilder<JS> b = context.js();
+		if ("java.lang.String".equals(leftType.toString()) && rightType.getKind() == TypeKind.CHAR) {
+            right = b.functionCall(b.property(b.name("String"), "fromCharCode"), asList(right));
+		} else if ("java.lang.String".equals(rightType.toString()) && leftType.getKind() == TypeKind.CHAR) {
+            left = b.functionCall(b.property(b.name("String"), "fromCharCode"), asList(left));
+        }
+
 		boolean integerDivision = tree.getKind() == Kind.DIVIDE && TypesUtils.isIntegral(leftType) && TypesUtils.isIntegral(rightType);
+
+		@SuppressWarnings("unchecked")
+        JS expr = b.binary(op, asList(left, right));
 
 		if (integerDivision) {
 			// force a cast for integer division to have the expected behavior in JavaScript too
-			JS target = context.js().property(context.js().name("stjs"), "trunc");
-			return context.js().functionCall(target, Collections.singleton(expr));
+			JS target = b.property(b.name("stjs"), "trunc");
+			return b.functionCall(target, Collections.singleton(expr));
 		}
 		return expr;
 	}

--- a/generator/src/main/java/org/stjs/generator/writer/expression/BinaryWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/BinaryWriter.java
@@ -2,7 +2,6 @@ package org.stjs.generator.writer.expression;
 
 import static java.util.Arrays.asList;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import javax.lang.model.type.TypeKind;
@@ -16,32 +15,29 @@ import org.stjs.generator.writer.WriterContributor;
 import org.stjs.generator.writer.WriterVisitor;
 
 import com.sun.source.tree.BinaryTree;
-import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
 
 public class BinaryWriter<JS> implements WriterContributor<BinaryTree, JS> {
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, BinaryTree tree, GenerationContext<JS> context) {
-	    JS left = visitor.scan(tree.getLeftOperand(), context);
-        JS right = visitor.scan(tree.getRightOperand(), context);
+		JS left = visitor.scan(tree.getLeftOperand(), context);
+		JS right = visitor.scan(tree.getRightOperand(), context);
 		BinaryOperator op = BinaryOperator.valueOf(tree.getKind());
 		assert op != null : "Unknow operator:" + tree.getKind();
-
 
 		TypeMirror leftType = context.getTrees().getTypeMirror(new TreePath(context.getCurrentPath(), tree.getLeftOperand()));
 		TypeMirror rightType = context.getTrees().getTypeMirror(new TreePath(context.getCurrentPath(), tree.getRightOperand()));
 		JavaScriptBuilder<JS> b = context.js();
-		if ("java.lang.String".equals(leftType.toString()) && rightType.getKind() == TypeKind.CHAR) {
-            right = b.functionCall(b.property(b.name("String"), "fromCharCode"), asList(right));
-		} else if ("java.lang.String".equals(rightType.toString()) && leftType.getKind() == TypeKind.CHAR) {
-            left = b.functionCall(b.property(b.name("String"), "fromCharCode"), asList(left));
-        }
-
+		if (isStringPlusChar(leftType, rightType)) {
+			right = b.functionCall(b.property(b.name("String"), "fromCharCode"), asList(right));
+		} else if (isStringPlusChar(rightType, leftType)) {
+			left = b.functionCall(b.property(b.name("String"), "fromCharCode"), asList(left));
+		}
 		boolean integerDivision = tree.getKind() == Kind.DIVIDE && TypesUtils.isIntegral(leftType) && TypesUtils.isIntegral(rightType);
 
 		@SuppressWarnings("unchecked")
-        JS expr = b.binary(op, asList(left, right));
+		JS expr = b.binary(op, asList(left, right));
 
 		if (integerDivision) {
 			// force a cast for integer division to have the expected behavior in JavaScript too
@@ -49,5 +45,9 @@ public class BinaryWriter<JS> implements WriterContributor<BinaryTree, JS> {
 			return b.functionCall(target, Collections.singleton(expr));
 		}
 		return expr;
+	}
+
+	private static boolean isStringPlusChar(TypeMirror left, TypeMirror right) {
+		return TypesUtils.isString(left) && right.getKind() == TypeKind.CHAR;
 	}
 }

--- a/generator/src/main/java/org/stjs/generator/writer/expression/LiteralWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/LiteralWriter.java
@@ -1,6 +1,9 @@
 package org.stjs.generator.writer.expression;
 
+import static java.util.Arrays.asList;
+
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.javascript.JavaScriptBuilder;
 import org.stjs.generator.javascript.Keyword;
 import org.stjs.generator.writer.WriterContributor;
 import org.stjs.generator.writer.WriterVisitor;
@@ -13,10 +16,13 @@ public class LiteralWriter<JS> implements WriterContributor<LiteralTree, JS> {
 	@Override
 	@SuppressWarnings("PMD.CyclomaticComplexity")
 	public JS visit(WriterVisitor<JS> visitor, LiteralTree tree, GenerationContext<JS> context) {
-		if (tree.getKind() == Kind.STRING_LITERAL || tree.getKind() == Kind.CHAR_LITERAL) {
-			return tree.getKind() == Kind.STRING_LITERAL ? context.js().string(tree.getValue().toString()) : context.js().character(
-					tree.getValue().toString());
-		}
+        if (tree.getKind() == Kind.STRING_LITERAL) {
+            return context.js().string(tree.getValue().toString());
+        } else if (tree.getKind() == Kind.CHAR_LITERAL) {
+            JavaScriptBuilder<JS> b = context.js();
+            JS expr = b.character(tree.getValue().toString());
+            return b.functionCall(b.property(expr, "charCodeAt"), asList(b.number(0)));
+        }
 		if (tree.getKind() == Kind.NULL_LITERAL) {
 			return context.js().keyword(Keyword.NULL);
 		}

--- a/generator/src/main/java/org/stjs/generator/writer/expression/LiteralWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/LiteralWriter.java
@@ -16,13 +16,13 @@ public class LiteralWriter<JS> implements WriterContributor<LiteralTree, JS> {
 	@Override
 	@SuppressWarnings("PMD.CyclomaticComplexity")
 	public JS visit(WriterVisitor<JS> visitor, LiteralTree tree, GenerationContext<JS> context) {
-        if (tree.getKind() == Kind.STRING_LITERAL) {
-            return context.js().string(tree.getValue().toString());
-        } else if (tree.getKind() == Kind.CHAR_LITERAL) {
-            JavaScriptBuilder<JS> b = context.js();
-            JS expr = b.character(tree.getValue().toString());
-            return b.functionCall(b.property(expr, "charCodeAt"), asList(b.number(0)));
-        }
+		if (tree.getKind() == Kind.STRING_LITERAL) {
+			return context.js().string(tree.getValue().toString());
+		} else if (tree.getKind() == Kind.CHAR_LITERAL) {
+			JavaScriptBuilder<JS> b = context.js();
+			JS expr = b.character(tree.getValue().toString());
+			return b.functionCall(b.property(expr, "charCodeAt"), asList(b.number(0)));
+		}
 		if (tree.getKind() == Kind.NULL_LITERAL) {
 			return context.js().keyword(Keyword.NULL);
 		}

--- a/generator/src/main/java/org/stjs/generator/writer/expression/NewArrayWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/NewArrayWriter.java
@@ -84,7 +84,7 @@ public class NewArrayWriter<JS> implements WriterContributor<NewArrayTree, JS> {
 	}
 
 	private void sanityCheck(GenerationContext<JS> context, TypedArrayTree t) {
-		if (t.jsTypeName == null || t.typeDim < 1) {
+		if (t.typeDim < 1) {
 			throw context.addError(t.tree, "Java array " + t.tree + " not supported.");
 		}
 		if (t.hasInitializer && t.hasDimension) {
@@ -96,7 +96,7 @@ public class NewArrayWriter<JS> implements WriterContributor<NewArrayTree, JS> {
 	private JS simpleArray(TypedArrayTree tree, GenerationContext<JS> context) {
 		JavaScriptBuilder<JS> b = context.js();
 		int typeDim = tree.typeDim;
-		if (typeDim > 1) {
+		if (typeDim > 1 || tree.jsTypeName == null) {
 			// float[][] a = {};
 			// var a = [];
 			return b.array(emptyList);
@@ -114,9 +114,10 @@ public class NewArrayWriter<JS> implements WriterContributor<NewArrayTree, JS> {
 		// float[][] a = {{}, {}};
 		// var a = [[], []];
 		JS args = initArgs(visitor, context, b, initializers);
-		if (typeDim > 1) {
+		if (typeDim > 1 || tree.jsTypeName == null) {
 			return args;
 		}
+
 		// var a = [1,2,3];
 		// new Float32Array([1,2,3])
 		return newPrimitiveArray(b, b.name(tree.jsTypeName), args);
@@ -125,9 +126,9 @@ public class NewArrayWriter<JS> implements WriterContributor<NewArrayTree, JS> {
 	private JS arrayFromDimension(WriterVisitor<JS> visitor, TypedArrayTree tree, GenerationContext<JS> context) {
 		JavaScriptBuilder<JS> b = context.js();
 		List<? extends ExpressionTree> dimensions = tree.dimensions;
-		JS typeName = b.name(tree.jsTypeName);
 		JS js;
-		if (tree.typeDim == dimensions.size()) {
+		if (tree.typeDim == dimensions.size() && tree.jsTypeName != null) {
+			JS typeName = b.name(tree.jsTypeName);
 			// float[] a = new float[3]
 			JS args = visitor.scan(dimensions.get(dimensions.size() - 1), context);
 			js = newPrimitiveArray(b, typeName, args);

--- a/generator/src/main/java/org/stjs/generator/writer/expression/NewArrayWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/NewArrayWriter.java
@@ -33,6 +33,7 @@ public class NewArrayWriter<JS> implements WriterContributor<NewArrayTree, JS> {
 
 	static {
 		java2js.put("int", "Int32Array");
+		java2js.put("boolean", "Int8Array");
 		java2js.put("byte", "Int8Array");
 		java2js.put("char", "Uint16Array");
 		java2js.put("short", "Int16Array");

--- a/generator/src/main/java/org/stjs/generator/writer/expression/NewArrayWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/NewArrayWriter.java
@@ -1,10 +1,26 @@
 package org.stjs.generator.writer.expression;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.stjs.generator.writer.JavascriptKeywords.NULL;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.javascript.JavaScriptBuilder;
 import org.stjs.generator.writer.WriterContributor;
 import org.stjs.generator.writer.WriterVisitor;
 
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewArrayTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Type.JCPrimitiveType;
+import com.sun.tools.javac.tree.JCTree.JCPrimitiveTypeTree;
 
 /**
  * useless as arrays are supposed to be checked before
@@ -13,8 +29,155 @@ import com.sun.source.tree.NewArrayTree;
  */
 public class NewArrayWriter<JS> implements WriterContributor<NewArrayTree, JS> {
 
+	private final List<JS> emptyList = Collections.<JS>emptyList();
+
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, NewArrayTree tree, GenerationContext<JS> context) {
+		String jsTypename = java2js.get(typeName(tree));
+		if (jsTypename == null) {
+			throw context.addError(tree, "Java array " + tree + " not supported.");
+		}
+		JavaScriptBuilder<JS> b = context.js();
+		JS typeName = b.name(jsTypename);
+		int dim = dim(tree);
+		List<? extends ExpressionTree> dimensions = tree.getDimensions();
+		List<? extends ExpressionTree> initializers = tree.getInitializers();
+		int initsize = initializers == null ? 0 : initializers.size();
+		int dimsize = dimensions.size();
+		if (dim == 1 && dimsize == 0 && initsize == 0) {
+			// new Float32Array()
+			return b.newExpression(typeName, emptyList);
+		}
+
+		if (dim == 1 && initsize == 1) {
+			// new Float32Array([1,2,3])
+			return b.newExpression(typeName, singleDimInit(b, visitor, context, tree.getInitializers().get(0)));
+		}
+		if (dim == 1 && initsize > 1) {
+			JS array = initArray(visitor, context, b, initializers);
+			return b.newExpression(typeName, singletonList(array));
+		}
+		if (dim > 1 && initsize >= 1) {
+			return initArray(visitor, context, b, initializers);
+		}
+
+		if (dim > 1 && dimsize == 0 && initsize == 0) {
+			return b.array(emptyList);
+		}
+		if (dimsize >= 1 && initsize == 0) {
+			JS _js = newPrimitiveArray(typeName, b, dimensions.get(dimsize - 1), visitor, context);
+			for (int i = dimsize - 2; i >= 0; i--) {
+				JS item = apply(b, newArray(b, dimensions.get(i), visitor, context));
+				_js = map(b, item, _js);
+			}
+			return _js;
+		}
+
 		throw context.addError(tree, "Java arrays are not supported. This is a ST-JS bug.");
+	}
+
+	private static Map<String, String> java2js = new HashMap<>();
+
+	static {
+		java2js.put("int", "Int32Array");
+		java2js.put("byte", "Int8Array");
+		java2js.put("char", "Uint16Array");
+		java2js.put("short", "Int16Array");
+		java2js.put("float", "Float32Array");
+		java2js.put("double", "Float64Array");
+	}
+
+	private static String typeName(NewArrayTree tree) {
+		Tree type = tree.getType();
+		if (type == null) {
+			try {
+				Field field = tree.getClass().getField("type");
+				Object _type = field.get(tree);
+				while (_type instanceof com.sun.tools.javac.code.Type.ArrayType) {
+					com.sun.tools.javac.code.Type.ArrayType atype = (com.sun.tools.javac.code.Type.ArrayType) _type;
+					com.sun.tools.javac.code.Type elemtype2 = atype.elemtype;
+					boolean primitive = elemtype2.isPrimitive();
+					if (primitive) {
+						JCPrimitiveType prim = (JCPrimitiveType) elemtype2;
+						return prim.toString();
+					}
+					_type = elemtype2;
+				}
+
+			}
+			catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+				return null;
+			}
+		} else if (type instanceof JCPrimitiveTypeTree) {
+			JCPrimitiveTypeTree prim = (JCPrimitiveTypeTree) type;
+			return prim.toString();
+
+		}
+		return null;
+	}
+
+	private JS initArray(WriterVisitor<JS> visitor, GenerationContext<JS> context, JavaScriptBuilder<JS> b,
+			List<? extends ExpressionTree> initializers) {
+		List<JS> _init = new ArrayList<>();
+		for (ExpressionTree init : initializers) {
+			_init.add(visitor.scan(init, context));
+		}
+		return b.array(_init);
+	}
+
+	private JS map(JavaScriptBuilder<JS> b, JS target, JS returns) {
+		return b.functionCall(map(b, target), singletonList(b.function(null, emptyList, b.returnStatement(returns))));
+	}
+
+	private JS newPrimitiveArray(JS typeName, JavaScriptBuilder<JS> b, ExpressionTree dim, WriterVisitor<JS> visitor,
+			GenerationContext<JS> context) {
+		return b.newExpression(typeName, singleDimension(visitor, context, dim));
+	}
+
+	private JS apply(JavaScriptBuilder<JS> b, JS newArray) {
+		return b.functionCall(arrayApply(b), asList(b.name(NULL), newArray));
+	}
+
+	private JS newArray(JavaScriptBuilder<JS> js, ExpressionTree dim, WriterVisitor<JS> visitor, GenerationContext<JS> context) {
+		return js.functionCall(js.name("Array"), singletonList(visitor.scan(dim, context)));
+	}
+
+	private JS map(JavaScriptBuilder<JS> js, JS first) {
+		return js.property(first, "map");
+	}
+
+	private JS arrayApply(JavaScriptBuilder<JS> js) {
+		return js.property(js.name("Array"), "apply");
+	}
+
+	private static int dim(NewArrayTree tree) {
+		Tree type = tree.getType();
+		int dim = tree.getDimensions().size();
+		if (dim == 0) {
+			try {
+				Field field = tree.getClass().getField("type");
+				Object _type = field.get(tree);
+				while (_type instanceof com.sun.tools.javac.code.Type.ArrayType) {
+					com.sun.tools.javac.code.Type.ArrayType atype = (com.sun.tools.javac.code.Type.ArrayType) _type;
+					com.sun.tools.javac.code.Type elemtype2 = atype.elemtype;
+					_type = elemtype2;
+					dim++;
+				}
+
+			}
+			catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+				return 0;
+			}
+		}
+		return dim;
+
+	}
+
+	private List<JS> singleDimension(WriterVisitor<JS> visitor, GenerationContext<JS> context, ExpressionTree dim) {
+		return singletonList(visitor.scan(dim, context));
+	}
+
+	private List<JS> singleDimInit(JavaScriptBuilder<JS> b, WriterVisitor<JS> visitor, GenerationContext<JS> context, ExpressionTree init) {
+		return singletonList(b.array(singletonList(visitor.scan(init, context))));
 	}
 }

--- a/generator/src/main/java/org/stjs/generator/writer/expression/TypeCastWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/TypeCastWriter.java
@@ -1,29 +1,110 @@
 package org.stjs.generator.writer.expression;
 
-import java.util.Collections;
+import static java.util.Arrays.asList;
+import static javax.lang.model.type.TypeKind.LONG;
+import static javax.lang.model.type.TypeKind.INT;
+import static javax.lang.model.type.TypeKind.SHORT;
+import static javax.lang.model.type.TypeKind.CHAR;
+import static javax.lang.model.type.TypeKind.BYTE;
+import static org.stjs.generator.javascript.BinaryOperator.LEFT_SHIFT;
+import static org.stjs.generator.javascript.BinaryOperator.RIGHT_SHIFT;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.EnumSet;
+
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.javac.TypesUtils;
+import org.stjs.generator.javascript.BinaryOperator;
+import org.stjs.generator.javascript.JavaScriptBuilder;
 import org.stjs.generator.writer.WriterContributor;
 import org.stjs.generator.writer.WriterVisitor;
 
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.util.TreePath;
+import com.sun.tools.javac.code.Type.JCPrimitiveType;
 
 public class TypeCastWriter<JS> implements WriterContributor<TypeCastTree, JS> {
+
+	private static final EnumSet<TypeKind> BIGGER_THAN_INT = EnumSet.of(LONG);
+	private static final EnumSet<TypeKind> BIGGER_THAN_CHAR = EnumSet.of(LONG, INT, SHORT);
+	private static final EnumSet<TypeKind> BIGGER_THAN_SHORT = EnumSet.of(LONG, INT, CHAR);
+	private static final EnumSet<TypeKind> BIGGER_THAN_BYTE = EnumSet.of(LONG, INT, SHORT, CHAR);
 
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, TypeCastTree tree, GenerationContext<JS> context) {
 		TypeMirror type = context.getTrees().getTypeMirror(new TreePath(context.getCurrentPath(), tree.getType()));
 		JS expr = visitor.scan(tree.getExpression(), context);
+		ExpressionTree expression = tree.getExpression();
+		TypeKind fromKind = getKind(expression);
+		TypeKind toKind = type.getKind();
+		JavaScriptBuilder<JS> b = context.js();
+
+		if (INT.equals(toKind) && BIGGER_THAN_INT.contains(fromKind)) {
+			// long l = 8*1024*1024*1024;
+			// int a = (int) l;
+			// var a = ((i)|0);
+
+			JS or = b.binary(BinaryOperator.OR, asList(b.paren(expr), b.number(0)));
+			return b.paren(or);
+		}
+		
+		if (BYTE.equals(toKind) && BIGGER_THAN_BYTE.contains(fromKind)) {
+			// long l = 8*1024*1024*1024;
+			// byte a = (byte) l;
+			// var a = (l<< 24 >> 24);
+
+			JS lsh = b.binary(LEFT_SHIFT, asList(expr, b.number(24)));
+			JS rsh = b.binary(RIGHT_SHIFT, asList(lsh, b.number(24)));
+			return b.paren(rsh);
+		}
+		
+		if (SHORT.equals(toKind) && BIGGER_THAN_SHORT.contains(fromKind)) {
+			// int i = 2*1024*1024*1024; //MAX_VALUE
+			// short a = (short) i;
+			// var a = ((i)<<16>>16);
+
+			JS lsh = b.binary(LEFT_SHIFT, asList(b.paren(expr), b.number(16)));
+			JS rsh = b.binary(RIGHT_SHIFT, asList(lsh, b.number(16)));
+			return b.paren(rsh);
+		}
+		
+		if (CHAR.equals(toKind) && BIGGER_THAN_CHAR.contains(fromKind)) {
+			// int i = 2*1024*1024*1024; //MAX_VALUE
+			// char a = (char) i;
+			// var a = ((i)&0xffff);
+
+			JS and = b.binary(BinaryOperator.AND, asList(b.paren(expr), b.number(0xffff)));
+			return b.paren(and);
+		}
+
 		if (TypesUtils.isIntegral(type)) {
 			// add explicit cast in this case
-			JS target = context.js().property(context.js().name("stjs"), "trunc");
-			expr = context.js().functionCall(target, Collections.singleton(expr));
+			JS target = b.property(b.name("stjs"), "trunc");
+			expr = b.functionCall(target, Collections.singleton(expr));
 		}
 		// otherwise skip to cast type - continue with the expression
 		return expr;
+	}
+
+	private TypeKind getKind(ExpressionTree expression) {
+		try {
+			Field field = expression.getClass().getField("type");
+			Object object = field.get(expression);
+			if (object instanceof JCPrimitiveType) {
+				JCPrimitiveType p = (JCPrimitiveType) object;
+				TypeKind kind = p.getKind();
+				return kind;
+			}
+		}
+		catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return null;
 	}
 }

--- a/generator/src/main/java/org/stjs/generator/writer/expression/TypeCastWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/TypeCastWriter.java
@@ -5,6 +5,8 @@ import static javax.lang.model.type.TypeKind.LONG;
 import static javax.lang.model.type.TypeKind.INT;
 import static javax.lang.model.type.TypeKind.SHORT;
 import static javax.lang.model.type.TypeKind.CHAR;
+import static javax.lang.model.type.TypeKind.DOUBLE;
+import static javax.lang.model.type.TypeKind.FLOAT;
 import static javax.lang.model.type.TypeKind.BYTE;
 import static org.stjs.generator.javascript.BinaryOperator.LEFT_SHIFT;
 import static org.stjs.generator.javascript.BinaryOperator.RIGHT_SHIFT;
@@ -30,10 +32,10 @@ import com.sun.tools.javac.code.Type.JCPrimitiveType;
 
 public class TypeCastWriter<JS> implements WriterContributor<TypeCastTree, JS> {
 
-	private static final EnumSet<TypeKind> BIGGER_THAN_INT = EnumSet.of(LONG);
-	private static final EnumSet<TypeKind> BIGGER_THAN_CHAR = EnumSet.of(LONG, INT, SHORT);
-	private static final EnumSet<TypeKind> BIGGER_THAN_SHORT = EnumSet.of(LONG, INT, CHAR);
-	private static final EnumSet<TypeKind> BIGGER_THAN_BYTE = EnumSet.of(LONG, INT, SHORT, CHAR);
+	private static final EnumSet<TypeKind> NEED_CAST_TO_INT = EnumSet.of(LONG);
+	private static final EnumSet<TypeKind> NEED_CAST_TO_CHAR = EnumSet.of(LONG, INT, SHORT, BYTE);
+	private static final EnumSet<TypeKind> NEED_CAST_TO_SHORT = EnumSet.of(LONG, INT, CHAR);
+	private static final EnumSet<TypeKind> NEED_CAST_TO_BYTE = EnumSet.of(LONG, INT, SHORT, CHAR);
 
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, TypeCastTree tree, GenerationContext<JS> context) {
@@ -44,7 +46,7 @@ public class TypeCastWriter<JS> implements WriterContributor<TypeCastTree, JS> {
 		TypeKind toKind = type.getKind();
 		JavaScriptBuilder<JS> b = context.js();
 
-		if (INT.equals(toKind) && BIGGER_THAN_INT.contains(fromKind)) {
+		if (INT.equals(toKind) && NEED_CAST_TO_INT.contains(fromKind)) {
 			// long l = 8*1024*1024*1024;
 			// int a = (int) l;
 			// var a = ((i)|0);
@@ -53,7 +55,7 @@ public class TypeCastWriter<JS> implements WriterContributor<TypeCastTree, JS> {
 			return b.paren(or);
 		}
 		
-		if (BYTE.equals(toKind) && BIGGER_THAN_BYTE.contains(fromKind)) {
+		if (BYTE.equals(toKind) && NEED_CAST_TO_BYTE.contains(fromKind)) {
 			// long l = 8*1024*1024*1024;
 			// byte a = (byte) l;
 			// var a = (l<< 24 >> 24);
@@ -63,7 +65,7 @@ public class TypeCastWriter<JS> implements WriterContributor<TypeCastTree, JS> {
 			return b.paren(rsh);
 		}
 		
-		if (SHORT.equals(toKind) && BIGGER_THAN_SHORT.contains(fromKind)) {
+		if (SHORT.equals(toKind) && NEED_CAST_TO_SHORT.contains(fromKind)) {
 			// int i = 2*1024*1024*1024; //MAX_VALUE
 			// short a = (short) i;
 			// var a = ((i)<<16>>16);
@@ -73,7 +75,7 @@ public class TypeCastWriter<JS> implements WriterContributor<TypeCastTree, JS> {
 			return b.paren(rsh);
 		}
 		
-		if (CHAR.equals(toKind) && BIGGER_THAN_CHAR.contains(fromKind)) {
+		if (CHAR.equals(toKind) && NEED_CAST_TO_CHAR.contains(fromKind)) {
 			// int i = 2*1024*1024*1024; //MAX_VALUE
 			// char a = (char) i;
 			// var a = ((i)&0xffff);

--- a/generator/src/main/java/org/stjs/generator/writer/statement/EnhancedForLoopWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/statement/EnhancedForLoopWriter.java
@@ -150,17 +150,15 @@ public class EnhancedForLoopWriter<JS> implements WriterContributor<EnhancedForL
 		//   }
 		String initialForLoopVariableName = tree.getVariable().getName().toString();
 
-		JS iteratorMethodCall = js.number(0);
-
-		String newIteratorName = "index$" + initialForLoopVariableName;
+		String newIndexName = "index$" + initialForLoopVariableName;
 		String newArrayName = "arr$" + initialForLoopVariableName;
-		JS newArray = js.name(newArrayName);
-		JS index = js.name(newIteratorName);
-		JS init = js.variableDeclaration(false, Arrays.asList(NameValue.of(newIteratorName, iteratorMethodCall), NameValue.of(newArrayName, iterated)));
-		JS condition = js.binary(BinaryOperator.LESS_THAN, Arrays.asList(index, js.property(newArray, "length")));
+		JS tmpArray = js.name(newArrayName);
+		JS index = js.name(newIndexName);
+		JS init = js.variableDeclaration(false, Arrays.asList(NameValue.of(newIndexName, js.number(0)), NameValue.of(newArrayName, iterated)));
+		JS condition = js.binary(BinaryOperator.LESS_THAN, Arrays.asList(index, js.property(tmpArray, "length")));
 		JS update = js.unary(UnaryOperator.POSTFIX_INCREMENT, index);
 
-		JS iteratorNextStatement = js.variableDeclaration(true, initialForLoopVariableName, js.elementGet(newArray, index));
+		JS iteratorNextStatement = js.variableDeclaration(true, initialForLoopVariableName, js.elementGet(tmpArray, index));
 		JS newBody = js.addStatementBeginning(body, iteratorNextStatement);
 
 		return context.withPosition(tree, context.js().forLoop(init, condition, update, newBody));

--- a/generator/src/main/java/org/stjs/generator/writer/statement/ExpressionStatementWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/statement/ExpressionStatementWriter.java
@@ -1,19 +1,47 @@
 package org.stjs.generator.writer.statement;
 
+import static java.util.Arrays.asList;
+
+import javax.lang.model.type.TypeKind;
+
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.javascript.AssignOperator;
+import org.stjs.generator.javascript.JavaScriptBuilder;
 import org.stjs.generator.writer.WriterContributor;
 import org.stjs.generator.writer.WriterVisitor;
 
 import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.tools.javac.tree.JCTree.JCAssignOp;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
 
 public class ExpressionStatementWriter<JS> implements WriterContributor<ExpressionStatementTree, JS> {
 
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, ExpressionStatementTree tree, GenerationContext<JS> context) {
-		JS expression = visitor.scan(tree.getExpression(), context);
+        JavaScriptBuilder<JS> js = context.js();
+        ExpressionTree expressionTree = tree.getExpression();
+	    if (Kind.PLUS_ASSIGNMENT.equals(expressionTree.getKind()) && expressionTree instanceof JCAssignOp) {
+            JCAssignOp asgn = (JCAssignOp) expressionTree;
+            JCExpression lhs = asgn.lhs;
+            JCExpression rhs = asgn.rhs;
+            if (TypeKind.CHAR == rhs.type.getKind()) {
+                //handle: 
+                //String s = "a";
+                //s += 'b';
+                JS left = visitor.scan(lhs, context);
+                JS right = visitor.scan(rhs, context);
+                right = js.functionCall(js.property(js.name("String"), "fromCharCode"), asList(right));
+                JS assignment = js.assignment(AssignOperator.PLUS_ASSIGNMENT, left, right);
+                return context.withPosition(tree, js.expressionStatement(assignment));
+            }
+        }
+		JS expression = visitor.scan(expressionTree, context);
 		if (expression == null) {
 			return null;
 		}
-		return context.withPosition(tree, context.js().expressionStatement(expression));
+        JS expressionStatement = js.expressionStatement(expression);
+        return context.withPosition(tree, expressionStatement);
 	}
 }

--- a/generator/src/main/java/org/stjs/generator/writer/statement/ExpressionStatementWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/statement/ExpressionStatementWriter.java
@@ -20,28 +20,28 @@ public class ExpressionStatementWriter<JS> implements WriterContributor<Expressi
 
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, ExpressionStatementTree tree, GenerationContext<JS> context) {
-        JavaScriptBuilder<JS> js = context.js();
-        ExpressionTree expressionTree = tree.getExpression();
-	    if (Kind.PLUS_ASSIGNMENT.equals(expressionTree.getKind()) && expressionTree instanceof JCAssignOp) {
-            JCAssignOp asgn = (JCAssignOp) expressionTree;
-            JCExpression lhs = asgn.lhs;
-            JCExpression rhs = asgn.rhs;
-            if (TypeKind.CHAR == rhs.type.getKind()) {
-                //handle: 
-                //String s = "a";
-                //s += 'b';
-                JS left = visitor.scan(lhs, context);
-                JS right = visitor.scan(rhs, context);
-                right = js.functionCall(js.property(js.name("String"), "fromCharCode"), asList(right));
-                JS assignment = js.assignment(AssignOperator.PLUS_ASSIGNMENT, left, right);
-                return context.withPosition(tree, js.expressionStatement(assignment));
-            }
-        }
+		JavaScriptBuilder<JS> js = context.js();
+		ExpressionTree expressionTree = tree.getExpression();
+		if (Kind.PLUS_ASSIGNMENT.equals(expressionTree.getKind()) && expressionTree instanceof JCAssignOp) {
+			JCAssignOp asgn = (JCAssignOp) expressionTree;
+			JCExpression lhs = asgn.lhs;
+			JCExpression rhs = asgn.rhs;
+			if (TypeKind.CHAR == rhs.type.getKind()) {
+				// handle:
+				// String s = "a";
+				// s += 'b';
+				JS left = visitor.scan(lhs, context);
+				JS right = visitor.scan(rhs, context);
+				right = js.functionCall(js.property(js.name("String"), "fromCharCode"), asList(right));
+				JS assignment = js.assignment(AssignOperator.PLUS_ASSIGNMENT, left, right);
+				return context.withPosition(tree, js.expressionStatement(assignment));
+			}
+		}
 		JS expression = visitor.scan(expressionTree, context);
 		if (expression == null) {
 			return null;
 		}
-        JS expressionStatement = js.expressionStatement(expression);
-        return context.withPosition(tree, expressionStatement);
+		JS expressionStatement = js.expressionStatement(expression);
+		return context.withPosition(tree, expressionStatement);
 	}
 }

--- a/generator/src/main/java/org/stjs/generator/writer/statement/ForLoopWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/statement/ForLoopWriter.java
@@ -49,7 +49,8 @@ public class ForLoopWriter<JS> implements WriterContributor<ForLoopTree, JS> {
 		if (tree.getCondition() != null) {
 			return visitor.scan(tree.getCondition(), p);
 		}
-		return null;
+        // 1) empty
+        return p.js().emptyExpression();
 	}
 
 	private JS update(WriterVisitor<JS> visitor, ForLoopTree tree, GenerationContext<JS> p) {

--- a/generator/src/main/java/org/stjs/generator/writer/statement/ForLoopWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/statement/ForLoopWriter.java
@@ -49,8 +49,8 @@ public class ForLoopWriter<JS> implements WriterContributor<ForLoopTree, JS> {
 		if (tree.getCondition() != null) {
 			return visitor.scan(tree.getCondition(), p);
 		}
-        // 1) empty
-        return p.js().emptyExpression();
+		// 1) empty
+		return p.js().emptyExpression();
 	}
 
 	private JS update(WriterVisitor<JS> visitor, ForLoopTree tree, GenerationContext<JS> p) {

--- a/generator/src/test/java/org/stjs/generator/exec/ints/ByteMath.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/ByteMath.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class ByteMath {
+	public static final byte B1 = 100;
+	public static final byte B2 = 50;
+
+	public static byte sum(byte b1, byte b2) {
+		return (byte) (val(b1) + b2);
+	}
+
+	private static byte val(byte a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return ByteMath.sum(B1, B2);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/CharAppendToString.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/CharAppendToString.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class CharAppendToString {
+    public static final char CYRILLIC_IA = 'я';
+
+    public static String method(String hello, char a) {
+        hello += func(a);
+        return hello;
+    }
+
+    private static char func(char a) {
+        return a;
+    }
+
+    public static String main(String[] args) {
+        return CharAppendToString.method("hello", CYRILLIC_IA);
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/CharLiteralToByte.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/CharLiteralToByte.java
@@ -1,0 +1,17 @@
+package org.stjs.generator.exec.ints;
+
+public class CharLiteralToByte {
+	public static final char CYRILLIC_IA = 'я';
+
+	public static byte method(char a) {
+		return val(a);
+	}
+
+	private static byte val(char a) {
+		return (byte) a;
+	}
+
+	public static int main(String[] args) {
+		return CharLiteralToByte.method(CYRILLIC_IA);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/CharPlusString.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/CharPlusString.java
@@ -1,0 +1,13 @@
+package org.stjs.generator.exec.ints;
+
+public class CharPlusString {
+    public static final char CYRILLIC_IA = 'я';
+
+    public static String method(String hello, char a) {
+        return hello + a;
+    }
+
+    public static String main(String[] args) {
+        return CharPlusString.method("hello", CYRILLIC_IA);
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/CharToByte.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/CharToByte.java
@@ -1,0 +1,17 @@
+package org.stjs.generator.exec.ints;
+
+public class CharToByte {
+	public static final char BIG_CHAR = 33001;
+
+	public static byte method(char a) {
+		return val(a);
+	}
+
+	private static byte val(char a) {
+		return (byte) a;
+	}
+
+	public static int main(String[] args) {
+		return CharToByte.method(BIG_CHAR);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/CharToShort.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/CharToShort.java
@@ -1,0 +1,17 @@
+package org.stjs.generator.exec.ints;
+
+public class CharToShort {
+	public static final char BIG_CHAR = 33001;
+
+	public static short method(char a) {
+		return (short) val(a);
+	}
+
+	private static char val(char a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return CharToShort.method(BIG_CHAR);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/CharsTest.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/CharsTest.java
@@ -1,0 +1,43 @@
+package org.stjs.generator.exec.ints;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.stjs.generator.utils.AbstractStjsTest;
+
+public class CharsTest extends AbstractStjsTest {
+
+    @Test
+    public void testCastCharToByte() {
+        byte expected = CharToByte.method(CharToByte.BIG_CHAR);
+        double expectedDouble = (double) expected;
+        assertEquals(expectedDouble, executeAndReturnNumber(CharToByte.class), 0);
+    }
+
+    @Test
+    public void testConcatStringAndChar() {
+        String expected = CharPlusString.method("hello", CharPlusString.CYRILLIC_IA);
+        assertEquals(expected, execute(CharPlusString.class));
+    }
+    
+    @Test
+    public void testAppendCharToString() {
+        String expected = CharAppendToString.method("hello", CharPlusString.CYRILLIC_IA);
+        assertEquals(expected, execute(CharAppendToString.class));
+    }
+
+    @Test
+    public void testCastCharLiteralToByte() {
+        byte expected = CharLiteralToByte.method(CharLiteralToByte.CYRILLIC_IA);
+        double expectedDouble = (double) expected;
+        assertEquals(expectedDouble, executeAndReturnNumber(CharLiteralToByte.class), 0);
+    }
+
+    @Test
+    public void testCastCharToShort() {
+        int expected = CharToShort.method(CharToShort.BIG_CHAR);
+        double expectedDouble = (double) expected;
+        assertEquals(expectedDouble, executeAndReturnNumber(CharToShort.class), 0);
+    }
+
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/FloatToInt.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/FloatToInt.java
@@ -1,0 +1,17 @@
+package org.stjs.generator.exec.ints;
+
+public class FloatToInt {
+	public static final float BIG_FLOAT = 2644245094.1f;
+
+	public static int method(float a) {
+		return (int) val(a);
+	}
+
+	private static float val(float a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return FloatToInt.method(BIG_FLOAT);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/IntToByte.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/IntToByte.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class IntToByte {
+	public static final int MAX_INT = 2147483647;
+	public static final int MIN_INT = -2147483648;
+
+	public static byte method(int a) {
+		return (byte) val(a);
+	}
+
+	private static int val(int a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return IntToByte.method(MAX_INT);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/IntToChar.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/IntToChar.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class IntToChar {
+	public static final int MAX_INT = 2147483647;
+	public static final int MIN_INT = -2147483648;
+
+	public static char method(int a) {
+		return (char) val(a);
+	}
+
+	private static int val(int a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return IntToChar.method(MAX_INT);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/IntToShort.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/IntToShort.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class IntToShort {
+	public static final int MAX_INT = 2147483647;
+	public static final int MIN_INT = -2147483648;
+
+	public static short method(int a) {
+		return (short) val(a);
+	}
+
+	private static int val(int a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return IntToShort.method(MAX_INT);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/IntToShortMin.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/IntToShortMin.java
@@ -1,0 +1,14 @@
+package org.stjs.generator.exec.ints;
+
+public class IntToShortMin {
+	public static final int MAX_INT = 2147483647;
+	public static final int MIN_INT = -2147483648;
+
+	public static short method(int a) {
+		return (short) a;
+	}
+
+	public static int main(String[] args) {
+		return IntToShortMin.method(MIN_INT);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/IntsTest.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/IntsTest.java
@@ -80,13 +80,6 @@ public class IntsTest extends AbstractStjsTest {
 	}
 
 	@Test
-	public void testCastCharToShort() {
-		int expected = CharToShort.method(CharToShort.BIG_CHAR);
-		double expectedDouble = (double) expected;
-		assertEquals(expectedDouble, executeAndReturnNumber(CharToShort.class), 0);
-	}
-
-	@Test
 	public void testCastShortToChar() {
 		int expected = ShortToChar.method(ShortToChar.NEG_SHORT);
 		double expectedDouble = (double) expected;

--- a/generator/src/test/java/org/stjs/generator/exec/ints/IntsTest.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/IntsTest.java
@@ -2,10 +2,19 @@ package org.stjs.generator.exec.ints;
 
 import static org.junit.Assert.*;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.stjs.generator.utils.AbstractStjsTest;
 
 public class IntsTest extends AbstractStjsTest {
+
+	@Test
+	public void testByteMath() throws Exception {
+		byte expected = ByteMath.sum(ByteMath.B1, ByteMath.B2);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(ByteMath.class), 0);
+
+	}
 
 	@Test
 	public void testCastIntToShort() {
@@ -82,6 +91,15 @@ public class IntsTest extends AbstractStjsTest {
 		int expected = ShortToChar.method(ShortToChar.NEG_SHORT);
 		double expectedDouble = (double) expected;
 		assertEquals(expectedDouble, executeAndReturnNumber(ShortToChar.class), 0);
+	}
+
+	@Test
+	@Ignore
+	public void testCastFloatToInt() {
+		// TODO: this does not pass - and i have no idea what to do just yet
+		int expected = FloatToInt.method(FloatToInt.BIG_FLOAT);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(FloatToInt.class), 0);
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/exec/ints/IntsTest.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/IntsTest.java
@@ -1,11 +1,88 @@
 package org.stjs.generator.exec.ints;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.stjs.generator.utils.AbstractStjsTest;
 
 public class IntsTest extends AbstractStjsTest {
+
+	@Test
+	public void testCastIntToShort() {
+		short expected = IntToShort.method(IntToShort.MAX_INT);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(IntToShort.class), 0);
+	}
+
+	@Test
+	public void testCastIntToChar() {
+		char expected = IntToChar.method(IntToShort.MAX_INT);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(IntToChar.class), 0);
+	}
+
+	@Test
+	public void testCastIntToByte() {
+		byte expected = IntToByte.method(IntToByte.MAX_INT);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(IntToByte.class), 0);
+	}
+
+	@Test
+	public void testCastIntToShortMin() {
+		short expected = IntToShort.method(IntToShort.MIN_INT);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(IntToShortMin.class), 0);
+	}
+
+	@Test
+	public void testCastLongToInt() {
+		int expected = LongToInt.method(LongToInt.BIG_LONG);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(LongToInt.class), 0);
+	}
+
+	@Test
+	public void testCastLongToShort() {
+		int expected = LongToShort.method(LongToShort.BIG_LONG);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(LongToShort.class), 0);
+	}
+
+	@Test
+	public void testCastLongToChar() {
+		int expected = LongToChar.method(LongToChar.BIG_LONG);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(LongToChar.class), 0);
+	}
+
+	@Test
+	public void testCastLongToByte() {
+		int expected = LongToByte.method(LongToByte.BIG_LONG);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(LongToByte.class), 0);
+	}
+
+	@Test
+	public void testCastLongToByteSmall() {
+		int expected = LongToByteSmall.method(LongToByteSmall.SMALL_LONG);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(LongToByteSmall.class), 0);
+	}
+
+	@Test
+	public void testCastCharToShort() {
+		int expected = CharToShort.method(CharToShort.BIG_CHAR);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(CharToShort.class), 0);
+	}
+
+	@Test
+	public void testCastShortToChar() {
+		int expected = ShortToChar.method(ShortToChar.NEG_SHORT);
+		double expectedDouble = (double) expected;
+		assertEquals(expectedDouble, executeAndReturnNumber(ShortToChar.class), 0);
+	}
 
 	@Test
 	public void testCastInt() {

--- a/generator/src/test/java/org/stjs/generator/exec/ints/LongToByte.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/LongToByte.java
@@ -1,0 +1,19 @@
+package org.stjs.generator.exec.ints;
+
+public class LongToByte {
+	public static final long BIG_LONG = 6442450941L;
+	public static final long SMALL_LONG = 33000L;
+	public static final long NEG_BIG_LONG = -6442450941L;
+
+	public static byte method(long a) {
+		return (byte) val(a);
+	}
+
+	private static long val(long a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return LongToByte.method(BIG_LONG);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/LongToByteSmall.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/LongToByteSmall.java
@@ -1,0 +1,19 @@
+package org.stjs.generator.exec.ints;
+
+public class LongToByteSmall {
+	public static final long BIG_LONG = 6442450941L;
+	public static final long SMALL_LONG = 33000L;
+	public static final long NEG_BIG_LONG = -6442450941L;
+
+	public static byte method(long a) {
+		return (byte) val(a);
+	}
+
+	private static long val(long a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return LongToByteSmall.method(SMALL_LONG);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/LongToChar.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/LongToChar.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class LongToChar {
+	public static final long BIG_LONG = 6442450941L;
+	public static final long NEG_BIG_LONG = -6442450941L;
+
+	public static char method(long a) {
+		return (char) val(a);
+	}
+
+	private static long val(long a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return LongToChar.method(BIG_LONG);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/LongToInt.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/LongToInt.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class LongToInt {
+	public static final long BIG_LONG = 6442450941L;
+	public static final long NEG_BIG_LONG = -6442450941L;
+
+	public static int method(long a) {
+		return (int) val(a);
+	}
+
+	private static long val(long a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return LongToInt.method(BIG_LONG);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/LongToShort.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/LongToShort.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.exec.ints;
+
+public class LongToShort {
+	public static final long BIG_LONG = 6442450941L;
+	public static final long NEG_BIG_LONG = -6442450941L;
+
+	public static short method(long a) {
+		return (short) val(a);
+	}
+
+	private static long val(long a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return LongToShort.method(BIG_LONG);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/exec/ints/ShortToChar.java
+++ b/generator/src/test/java/org/stjs/generator/exec/ints/ShortToChar.java
@@ -1,0 +1,17 @@
+package org.stjs.generator.exec.ints;
+
+public class ShortToChar {
+	public static final short NEG_SHORT = -31001;
+
+	public static char method(short a) {
+		return (char) val(a);
+	}
+
+	private static short val(short a) {
+		return a;
+	}
+
+	public static int main(String[] args) {
+		return ShortToChar.method(NEG_SHORT);
+	}
+}

--- a/generator/src/test/java/org/stjs/generator/writer/enums/EnumGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/enums/EnumGeneratorTest.java
@@ -1,5 +1,7 @@
 package org.stjs.generator.writer.enums;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.stjs.generator.utils.AbstractStjsTest;
 import org.stjs.generator.JavascriptFileGenerationException;
@@ -31,8 +33,8 @@ public class EnumGeneratorTest extends AbstractStjsTest {
 
 	@Test
 	public void testEnumValues() {
-		assertCodeContains(Enums6.class, "for(var v in Enums6.Value.values())");
-		assertCodeContains(Enums6.class, "constructor.Value = stjs.enumeration(\"a\", \"b\", \"c\");");
+		String expected = Enums6.main(null);
+		assertEquals(expected, execute(Enums6.class));
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/enums/Enums6.java
+++ b/generator/src/test/java/org/stjs/generator/writer/enums/Enums6.java
@@ -6,9 +6,11 @@ public class Enums6 {
 	}
 
 	@SuppressWarnings("unused")
-	public void main() {
+	public static String main(String[] args) {
+		String result = "";
 		for (Value v : Value.values()) {
-			//
+			result += v.name() + ":" + v.ordinal();
 		}
+		return result;
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/statements/Statements2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/Statements2.java
@@ -1,9 +1,0 @@
-package org.stjs.generator.writer.statements;
-
-public class Statements2 {
-	@SuppressWarnings("unused")
-	public static void main(String[] args) {
-		for (String arg : args) {
-		}
-	}
-}

--- a/generator/src/test/java/org/stjs/generator/writer/statements/Statements20d.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/Statements20d.java
@@ -1,0 +1,13 @@
+package org.stjs.generator.writer.statements;
+
+public class Statements20d {
+    public static int method() {
+        int j = 0;
+        for (int i = 0;; ++i) {
+            //
+            j = 42;
+            break;
+        }
+        return j;
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/statements/Statements20e.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/Statements20e.java
@@ -1,0 +1,13 @@
+package org.stjs.generator.writer.statements;
+
+public class Statements20e {
+    public static int method() {
+        int j = 0;
+        for (int i = 0;i<10;) {
+            //
+            j = 42;
+            break;
+        }
+        return j;
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -155,6 +155,17 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 	public void testForNoInit() {
 		assertCodeContains(Statements20c.class, "for(; i < 10; ++i){}");
 	}
+	
+	@Test
+    public void testForNoCondition() {
+        assertCodeContains(Statements20d.class, "for(var i=0; ; ++i)");
+    }
+
+	@Test
+    public void testForNoUpdate() {
+        assertCodeContains(Statements20e.class, "for(var i=0;i<10;)");
+    }
+
 
 	@Test
 	public void testStaticBlock() {

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -14,12 +14,6 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 	}
 
 	@Test
-	public void testForEach() {
-		// XXX this is not exactly correct as arg here is the index not the value
-		assertCodeContains(Statements2.class, "for (var arg in args) {");
-	}
-
-	@Test
 	public void testWhile() {
 		assertCodeContains(Statements3.class, "while(i < 5) {");
 	}

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -69,7 +69,7 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testLiterals() {
 		// "abc", "\"", "'", 'a', '\'', 1D, 2f, 1l);
-		assertCodeContains(Statements9.class, "\"abc\", \"\\\"\", \"'\", 'a', '\\'', 1.0, 2.0, 1");
+		assertCodeContains(Statements9.class, "\"abc\", \"\\\"\", \"'\", 'a'.charCodeAt(0), '\\''.charCodeAt(0), 1.0, 2.0, 1");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -31,9 +31,8 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 		assertCodeContains(Statements4.class, "default: break");
 	}
 
-	@Test(expected = JavascriptFileGenerationException.class)
 	public void testArray1() {
-		generate(Statements5.class);
+		assertCodeContains(Statements5.class, "new Int32Array([1, 2, 3])");
 	}
 
 	@Test(expected = JavascriptFileGenerationException.class)

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -35,10 +35,8 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 		assertCodeContains(Statements5.class, "new Int32Array([1, 2, 3])");
 	}
 
-	@Test(expected = JavascriptFileGenerationException.class)
 	public void testArray2() {
-		// java array creation is forbidden
-		generate(Statements6.class);
+		assertCodeContains(Statements6.class, "[1, 2, 3]");
 	}
 
 	@Ignore

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayInstanceOf.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayInstanceOf.java
@@ -1,0 +1,20 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class ArrayInstanceOf {
+	public static int intArray() {
+		byte[] b = new byte[1];
+		Object o = b;
+        if (o instanceof Object[]) {
+            return 43;
+        }
+        if (o instanceof byte[]) {
+            return 44;
+        }
+		return 42;
+	}
+	
+	public static int main(String[] args) {
+        return intArray();
+    }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayMath.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayMath.java
@@ -1,0 +1,21 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class ArrayMath {
+	public static int method() {
+		int[] a = { 1, 2, 3, 4 };
+		int[] b = { 2, 2, 2, 2 };
+		int[] c = new int[4];
+		int sum = 0;
+		for (int i = 0; i < a.length; i++) {
+			c[i] = a[i] + b[i];
+			c[i]++;
+			sum += c[i];
+		}
+		return sum;
+	}
+
+	public static int main(String[] args) {
+		return ArrayMath.method();
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayTest.java
@@ -1,0 +1,34 @@
+package org.stjs.generator.writer.typedarrays;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.stjs.generator.utils.AbstractStjsTest;
+
+public class ArrayTest extends AbstractStjsTest {
+	@Test
+	public void testSimple() throws Exception {
+		assertCodeContains(StringArrayInit.class, "var arr = Array(1); var simple = [];");
+	}
+
+	@Test
+	public void testOneDimInit() throws Exception {
+		String expected = "var arr = [ \"\", null, \"hello\", \"world\", this.a() ]";
+		assertCodeContains(StringArrayInit1.class, expected);
+	}
+
+	@Test
+	public void testMultiDim() throws Exception {
+		String expected = "Array.apply(null, Array(1))" //
+				+ ".map(function(){return Array.apply(null, Array(2))" //
+				+ ".map(function(){return Array(3);});});";
+		assertCodeContains(MultiStringArrayInit.class, expected);
+	}
+
+	@Test
+	public void testCrazy() throws Exception {
+		String expected = "[[[\"hello\"], [\"world\"], []], [[1, 2], [3, 4]], Array.apply(null, Array(4)).map(function() {return Array(5);})]";
+		assertCodeContains(ObjectMultiInit2.class, expected);
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/ArrayTest.java
@@ -31,4 +31,9 @@ public class ArrayTest extends AbstractStjsTest {
 		assertCodeContains(ObjectMultiInit2.class, expected);
 	}
 
+	@Test
+	public void testEnhancedForLoopArray() throws Exception {
+		String expected = EnhancedForLoopArray.method();
+		assertEquals(expected, execute(EnhancedForLoopArray.class));
+	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/BooleanArray.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/BooleanArray.java
@@ -1,0 +1,22 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class BooleanArray {
+	public static int method() {
+		int _i = 1;
+		boolean[] a = new boolean[3];
+		a[0] = 42 != Float.NaN;
+		a[1] = 42 != 43;
+		a[2] = 42. == 41 + _i;
+
+		boolean truth = true;
+		for (int i = 0; i < a.length; i++) {
+			truth &= a[i];
+		}
+		return truth ? 42 : 43;
+	}
+
+	public static int main(String[] args) {
+		return BooleanArray.method();
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/EnhancedForLoopArray.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/EnhancedForLoopArray.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class EnhancedForLoopArray {
+
+	static String method() {
+		String[] arr = { "hello", "world" };
+		String result = "";
+		for (String string : arr) {
+			result += string;
+		}
+		return result;
+	}
+
+	public static String main(String[] args) {
+		return EnhancedForLoopArray.method();
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/EnhancedForLoopArray.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/EnhancedForLoopArray.java
@@ -2,13 +2,20 @@ package org.stjs.generator.writer.typedarrays;
 
 public class EnhancedForLoopArray {
 
+	private static int counter;
+
+	private static String[] makeArray() {
+		counter++;
+		return new String[]{ "hello", "world" };
+	}
+
 	static String method() {
-		String[] arr = { "hello", "world" };
+		counter = 0;
 		String result = "";
-		for (String string : arr) {
+		for (String string : makeArray()) {
 			result += string;
 		}
-		return result;
+		return result + counter;
 	}
 
 	public static String main(String[] args) {

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/EnhancedForLoopIntArray.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/EnhancedForLoopIntArray.java
@@ -1,0 +1,18 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class EnhancedForLoopIntArray {
+
+	static int method() {
+		int[] arr = { 42, 43 };
+		int result = 0;
+		for (int item : arr) {
+			result += item;
+		}
+		return result;
+	}
+
+	public static int main(String[] args) {
+		return EnhancedForLoopIntArray.method();
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit.java
@@ -4,24 +4,4 @@ public class Float32ArrayInit {
 	public void test1() {
 		float[] arr = new float[1];
 	}
-
-//	public void testInit() {
-//		float[] arr = { 1.2f, 2f, 3, .4f };
-//	}
-//	
-//
-//	public void testNewInit() {
-//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
-//	}
-//
-//	public void test11() {
-//		float arr[][] = new float[1][1];
-//	}
-//
-//	public void test1_() {
-//		float arr[][] = new float[1][];
-//		arr[0][0] = 1f;
-//	}
-
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit.java
@@ -1,0 +1,27 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class Float32ArrayInit {
+	public void test1() {
+		float[] arr = new float[1];
+	}
+
+//	public void testInit() {
+//		float[] arr = { 1.2f, 2f, 3, .4f };
+//	}
+//	
+//
+//	public void testNewInit() {
+//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
+//	}
+//
+//	public void test11() {
+//		float arr[][] = new float[1][1];
+//	}
+//
+//	public void test1_() {
+//		float arr[][] = new float[1][];
+//		arr[0][0] = 1f;
+//	}
+
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0.java
@@ -5,10 +5,4 @@ public class Float32ArrayInit0 {
 	public void test11() {
 		float[] arr = new float[]{};
 	}
-
-	// public void test1_() {
-	// float arr[][] = new float[1][];
-	// arr[0][0] = 1f;
-	// }
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0.java
@@ -1,0 +1,14 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class Float32ArrayInit0 {
+
+	public void test11() {
+		float[] arr = new float[]{};
+	}
+
+	// public void test1_() {
+	// float arr[][] = new float[1][];
+	// arr[0][0] = 1f;
+	// }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0Empty.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0Empty.java
@@ -5,10 +5,4 @@ public class Float32ArrayInit0Empty {
 	public void test11() {
 		float[] arr = {};
 	}
-
-	// public void test1_() {
-	// float arr[][] = new float[1][];
-	// arr[0][0] = 1f;
-	// }
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0Empty.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit0Empty.java
@@ -1,0 +1,14 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class Float32ArrayInit0Empty {
+
+	public void test11() {
+		float[] arr = {};
+	}
+
+	// public void test1_() {
+	// float arr[][] = new float[1][];
+	// arr[0][0] = 1f;
+	// }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit1.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit1.java
@@ -1,0 +1,27 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class Float32ArrayInit1 {
+	public void testInit() {
+		float[] arr = { 1.2f, 2f, 3, .4f, a() };
+	}
+	
+	public int a() {
+		return 42;
+	}
+	
+//
+//	public void testNewInit() {
+//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
+//	}
+//
+//	public void test11() {
+//		float arr[][] = new float[1][1];
+//	}
+//
+//	public void test1_() {
+//		float arr[][] = new float[1][];
+//		arr[0][0] = 1f;
+//	}
+
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit1.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit1.java
@@ -8,20 +8,4 @@ public class Float32ArrayInit1 {
 	public int a() {
 		return 42;
 	}
-	
-//
-//	public void testNewInit() {
-//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
-//	}
-//
-//	public void test11() {
-//		float arr[][] = new float[1][1];
-//	}
-//
-//	public void test1_() {
-//		float arr[][] = new float[1][];
-//		arr[0][0] = 1f;
-//	}
-
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit2.java
@@ -1,0 +1,21 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class Float32ArrayInit2 {
+	public void testInit() {
+		float[] arr = new float[]{ 1.2f, 2f, 3, .4f, a() };
+	}
+
+	public int a() {
+		return 42;
+	}
+
+	// public void test11() {
+	// float arr[][] = new float[1][1];
+	// }
+	//
+	// public void test1_() {
+	// float arr[][] = new float[1][];
+	// arr[0][0] = 1f;
+	// }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Float32ArrayInit2.java
@@ -8,14 +8,4 @@ public class Float32ArrayInit2 {
 	public int a() {
 		return 42;
 	}
-
-	// public void test11() {
-	// float arr[][] = new float[1][1];
-	// }
-	//
-	// public void test1_() {
-	// float arr[][] = new float[1][];
-	// arr[0][0] = 1f;
-	// }
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/LongArray.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/LongArray.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class LongArray {
+	public void init() {
+		long[] l = {};
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit.java
@@ -1,0 +1,27 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiF32AInit {
+	public void test1() {
+		float[][][] arr = new float[1][2][3];
+	}
+
+//	public void testInit() {
+//		float[] arr = { 1.2f, 2f, 3, .4f };
+//	}
+//	
+//
+//	public void testNewInit() {
+//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
+//	}
+//
+//	public void test11() {
+//		float arr[][] = new float[1][1];
+//	}
+//
+//	public void test1_() {
+//		float arr[][] = new float[1][];
+//		arr[0][0] = 1f;
+//	}
+
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit.java
@@ -4,24 +4,4 @@ public class MultiF32AInit {
 	public void test1() {
 		float[][][] arr = new float[1][2][3];
 	}
-
-//	public void testInit() {
-//		float[] arr = { 1.2f, 2f, 3, .4f };
-//	}
-//	
-//
-//	public void testNewInit() {
-//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
-//	}
-//
-//	public void test11() {
-//		float arr[][] = new float[1][1];
-//	}
-//
-//	public void test1_() {
-//		float arr[][] = new float[1][];
-//		arr[0][0] = 1f;
-//	}
-
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0.java
@@ -5,10 +5,4 @@ public class MultiF32AInit0 {
 	public void test11() {
 		float[][][] arr = new float[][][]{ { {} }, };
 	}
-
-	// public void test1_() {
-	// float arr[][] = new float[1][];
-	// arr[0][0] = 1f;
-	// }
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0.java
@@ -1,0 +1,14 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiF32AInit0 {
+
+	public void test11() {
+		float[][][] arr = new float[][][]{ { {} }, };
+	}
+
+	// public void test1_() {
+	// float arr[][] = new float[1][];
+	// arr[0][0] = 1f;
+	// }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty.java
@@ -1,0 +1,14 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiF32AInit0Empty {
+
+	public void test11() {
+		float[][][] arr = {};
+	}
+
+	// public void test1_() {
+	// float arr[][] = new float[1][];
+	// arr[0][0] = 1f;
+	// }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty.java
@@ -5,10 +5,4 @@ public class MultiF32AInit0Empty {
 	public void test11() {
 		float[][][] arr = {};
 	}
-
-	// public void test1_() {
-	// float arr[][] = new float[1][];
-	// arr[0][0] = 1f;
-	// }
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty2.java
@@ -5,10 +5,4 @@ public class MultiF32AInit0Empty2 {
 	public void test11() {
 		float[][][] arr2 = {{}};
 	}
-
-	// public void test1_() {
-	// float arr[][] = new float[1][];
-	// arr[0][0] = 1f;
-	// }
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty2.java
@@ -1,0 +1,14 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiF32AInit0Empty2 {
+
+	public void test11() {
+		float[][][] arr2 = {{}};
+	}
+
+	// public void test1_() {
+	// float arr[][] = new float[1][];
+	// arr[0][0] = 1f;
+	// }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty3.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty3.java
@@ -1,0 +1,14 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiF32AInit0Empty3 {
+
+	public void test11() {
+		float[][][] arr3 = {{{}}};
+	}
+
+	// public void test1_() {
+	// float arr[][] = new float[1][];
+	// arr[0][0] = 1f;
+	// }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty3.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit0Empty3.java
@@ -5,10 +5,4 @@ public class MultiF32AInit0Empty3 {
 	public void test11() {
 		float[][][] arr3 = {{{}}};
 	}
-
-	// public void test1_() {
-	// float arr[][] = new float[1][];
-	// arr[0][0] = 1f;
-	// }
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit1.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiF32AInit1.java
@@ -1,0 +1,25 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiF32AInit1 {
+	public void testInit() {
+		float[][][] arr = 
+			{ 
+				{ 
+					{ 1.2f, 2f, 3, .4f, a() }, 
+					{}, 
+					new float[1], 
+					myarray() 
+				}, 
+				{} 
+			};
+	}
+
+	private float[] myarray() {
+		return new float[3];
+	}
+
+	public int a() {
+		return 42;
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiInit.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiInit {
+	public void testName() {
+        int[][][] arr = new int[3][2][];
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiInit2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiInit2.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiInit2 {
+	public void testName() {
+        int[][][] ac = new int[][][] { new int[2][3], new int[4][5], new int[6][7] };
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiStringArrayInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/MultiStringArrayInit.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class MultiStringArrayInit {
+	public void test1() {
+		String[][][] arr = new String[1][2][3];
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/ObjectMultiInit2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/ObjectMultiInit2.java
@@ -1,0 +1,10 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class ObjectMultiInit2 {
+	public static Object[][][] testName() {
+		Object[][][] ac = new Object[][][]{ new String[][]{ { "hello" }, { "world" }, new String[]{} }, new Integer[][]{ { 1, 2 }, { 3, 4 } },
+				new Double[4][5] };
+		return ac;
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/PrimitiveArrayFields.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/PrimitiveArrayFields.java
@@ -1,0 +1,21 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class PrimitiveArrayFields {
+    boolean[] bool;
+    byte[] b;
+    short[] s;
+    char[] c;
+    int[] i;
+    float[] f;
+    double[] d;
+
+    boolean[][] bool2d;
+    
+    boolean _bool;
+    byte _b;
+    short _s;
+    char _c;
+    int _i;
+    float _f;
+    double _d;
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringArrayInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringArrayInit.java
@@ -1,0 +1,9 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class StringArrayInit {
+	public void test1() {
+		String[] arr = new String[1];
+		String[] simple = new String[]{};
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringArrayInit1.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringArrayInit1.java
@@ -8,20 +8,4 @@ public class StringArrayInit1 {
 	public String a() {
 		return "42";
 	}
-	
-//
-//	public void testNewInit() {
-//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
-//	}
-//
-//	public void test11() {
-//		float arr[][] = new float[1][1];
-//	}
-//
-//	public void test1_() {
-//		float arr[][] = new float[1][];
-//		arr[0][0] = 1f;
-//	}
-
-
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringArrayInit1.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringArrayInit1.java
@@ -1,0 +1,27 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class StringArrayInit1 {
+	public void testInit() {
+		String[] arr = { "", null, "hello", "world", a() };
+	}
+	
+	public String a() {
+		return "42";
+	}
+	
+//
+//	public void testNewInit() {
+//		float arr[] = new float[]{ 1.2f, 2f, 3, .4f };
+//	}
+//
+//	public void test11() {
+//		float arr[][] = new float[1][1];
+//	}
+//
+//	public void test1_() {
+//		float arr[][] = new float[1][];
+//		arr[0][0] = 1f;
+//	}
+
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringMultiInit.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/StringMultiInit.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class StringMultiInit {
+	public void testName() {
+		String[][][] arr = new String[3][2][];
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -1,0 +1,100 @@
+package org.stjs.generator.writer.typedarrays;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.stjs.generator.utils.AbstractStjsTest;
+
+public class TypedArrayTest extends AbstractStjsTest {
+
+	int ga() {
+		return 42;
+	}
+
+	@Test
+	public void testDummy() throws Exception {
+		float arr[][] = new float[ga()][];
+		System.out.println(arr[0]);
+		float[][] arr2 = { {}, {} };
+		System.out.println(arr2);
+
+	}
+
+	@Test
+	public void testFloatArray() throws Exception {
+		assertCodeContains(Float32ArrayInit.class, "new Float32Array(1)");
+	}
+
+	@Test
+	public void testMF32AInit() throws Exception {
+		assertCodeContains(MultiF32AInit.class,
+				"Array.apply(null, Array(1))" //
+						+ ".map(function(){return Array.apply(null, Array(2))" //
+						+ ".map(function(){return new Float32Array(3);});});");
+	}
+
+	@Test
+	public void testFloatArrayInit0() throws Exception {
+		assertCodeContains(Float32ArrayInit0.class, "new Float32Array()");
+	}
+
+	@Test
+	public void testFloatArrayInit00() throws Exception {
+		assertCodeContains(Float32ArrayInit0Empty.class, "var arr = new Float32Array()");
+	}
+
+	@Test
+	public void testMultiF32AInit0Empty() throws Exception {
+		assertCodeContains(MultiF32AInit0Empty.class, "var arr = [];");
+	}
+
+	@Test
+	public void testMultiF32AInit0Empty2() throws Exception {
+		assertCodeContains(MultiF32AInit0Empty2.class, "var arr2 = [[]];");
+	}
+
+	@Test
+	public void testMultiF32AInit0Empty3() throws Exception {
+		assertCodeContains(MultiF32AInit0Empty3.class, "var arr3 = [[new Float32Array()]];");
+	}
+
+	@Test
+	public void testFloatArrayInit1() throws Exception {
+		assertCodeContains(Float32ArrayInit1.class, "new Float32Array([1.2, 2.0, 3, 0.4, this.a()])");
+	}
+
+	@Test
+	public void testMultiFloatArrayInit1() throws Exception {
+		/* @formatter:off */
+		assertCodeContains(MultiF32AInit1.class, 
+				"["
+				+ "["
+			  		+ "new Float32Array([1.2, 2.0, 3, 0.4, this.a()]),"
+			  		+ "new Float32Array(),"
+			  		+ "new Float32Array(1),"
+			  		+ "this.myarray()"
+			  	+ "],"
+			  	+ "[]"
+		  	+ "]");
+		/* @formatter:on */
+	}
+
+	@Test
+	public void testFloatArrayInit2() throws Exception {
+		assertCodeContains(Float32ArrayInit2.class, "new Float32Array([1.2, 2.0, 3, 0.4, this.a()])");
+	}
+
+	@Test
+	public void testTypes() throws Exception {
+		String generated = generate(Types.class);
+		System.out.println(generated);
+		assertCodeContains(generated, "new Int8Array()");
+		assertCodeContains(generated, "new Int16Array()");
+		assertCodeContains(generated, "new Uint16Array()");
+		assertCodeContains(generated, "new Int32Array()");
+		assertCodeContains(generated, "new Float32Array()");
+		assertCodeContains(generated, "new Float64Array()");
+
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -84,4 +84,11 @@ public class TypedArrayTest extends AbstractStjsTest {
 
 	}
 
+	@Test
+	public void testArrayMath() throws Exception {
+		assertCodeContains(ArrayMath.class, "c[i]++;");
+		int expected = ArrayMath.method();
+		assertEquals((double) expected, executeAndReturnNumber(ArrayMath.class), 0);
+	}
+
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -74,14 +74,13 @@ public class TypedArrayTest extends AbstractStjsTest {
 	@Test
 	public void testTypes() throws Exception {
 		String generated = generate(Types.class);
-		System.out.println(generated);
-		assertCodeContains(generated, "new Int8Array()");
-		assertCodeContains(generated, "new Int16Array()");
-		assertCodeContains(generated, "new Uint16Array()");
-		assertCodeContains(generated, "new Int32Array()");
-		assertCodeContains(generated, "new Float32Array()");
-		assertCodeContains(generated, "new Float64Array()");
-
+		assertCodeContains(generated, "var bool = new Int8Array()");
+		assertCodeContains(generated, "var b = new Int8Array()");
+		assertCodeContains(generated, "var s = new Int16Array()");
+		assertCodeContains(generated, "var c = new Uint16Array()");
+		assertCodeContains(generated, "var i = new Int32Array()");
+		assertCodeContains(generated, "var f = new Float32Array()");
+		assertCodeContains(generated, "var d = new Float64Array()");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -90,5 +90,10 @@ public class TypedArrayTest extends AbstractStjsTest {
 		int expected = ArrayMath.method();
 		assertEquals((double) expected, executeAndReturnNumber(ArrayMath.class), 0);
 	}
+	@Test
+	public void testBooleanArray() throws Exception {
+		int expected = BooleanArray.method();
+		assertEquals((double) expected, executeAndReturnNumber(BooleanArray.class), 0);
+	}		
 
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -7,19 +7,6 @@ import org.stjs.generator.utils.AbstractStjsTest;
 
 public class TypedArrayTest extends AbstractStjsTest {
 
-	int ga() {
-		return 42;
-	}
-
-	@Test
-	public void testDummy() throws Exception {
-		float arr[][] = new float[ga()][];
-		System.out.println(arr[0]);
-		float[][] arr2 = { {}, {} };
-		System.out.println(arr2);
-
-	}
-
 	@Test
 	public void testFloatArray() throws Exception {
 		assertCodeContains(Float32ArrayInit.class, "new Float32Array(1)");

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -82,6 +82,12 @@ public class TypedArrayTest extends AbstractStjsTest {
 		assertCodeContains(generated, "var f = new Float32Array()");
 		assertCodeContains(generated, "var d = new Float64Array()");
 	}
+	
+	@Test
+    public void testPrimitiveArrayFields() throws Exception {
+        String generated = generate(PrimitiveArrayFields.class);
+        assertCodeContains(generated, "bool: \"Int8Array\", b: \"Int8Array\", s: \"Int16Array\", c: \"Uint16Array\", i: \"Int32Array\", f: \"Float32Array\", d: \"Float64Array\", bool2d: \"Array\"");
+    }
 
 	@Test
 	public void testMultiInit() throws Exception {
@@ -116,5 +122,11 @@ public class TypedArrayTest extends AbstractStjsTest {
 		int expected = BooleanArray.method();
 		assertEquals((double) expected, executeAndReturnNumber(BooleanArray.class), 0);
 	}
-
+	
+	@Test
+	public void testInstanceOf() {
+		String generated = generate(ArrayInstanceOf.class);
+		assertCodeContains(generated, "isInstanceOf(o.constructor, Int8Array)");
+		assertEquals(44., executeAndReturnNumber(ArrayInstanceOf.class), 0.01);
+	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -85,15 +85,37 @@ public class TypedArrayTest extends AbstractStjsTest {
 	}
 
 	@Test
+	public void testMultiInit() throws Exception {
+		String expected = "Array.apply(null, Array(3)).map(function(){return Array(2);});"; //
+		assertCodeContains(MultiInit.class, expected);
+	}
+
+	@Test
+	public void testMultiInit2() throws Exception {
+		/* @formatter:off */
+		String expected = 
+		"var ac = [Array.apply(null, Array(2)).map(function() {"+//
+        "    return new Int32Array(3);"+//
+        "}), Array.apply(null, Array(4)).map(function() {"+//
+        "    return new Int32Array(5);"+//
+        "}), Array.apply(null, Array(6)).map(function() {"+//
+        "    return new Int32Array(7);"+//
+        "})]";
+		/* @formatter:on */
+		assertCodeContains(MultiInit2.class, expected);
+	}
+
+	@Test
 	public void testArrayMath() throws Exception {
 		assertCodeContains(ArrayMath.class, "c[i]++;");
 		int expected = ArrayMath.method();
 		assertEquals((double) expected, executeAndReturnNumber(ArrayMath.class), 0);
 	}
+
 	@Test
 	public void testBooleanArray() throws Exception {
 		int expected = BooleanArray.method();
 		assertEquals((double) expected, executeAndReturnNumber(BooleanArray.class), 0);
-	}		
+	}
 
 }

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/TypedArrayTest.java
@@ -8,6 +8,12 @@ import org.stjs.generator.utils.AbstractStjsTest;
 public class TypedArrayTest extends AbstractStjsTest {
 
 	@Test
+	public void testEnhancedForLoopArray() throws Exception {
+		int expected = EnhancedForLoopIntArray.method();
+		assertEquals(expected, executeAndReturnNumber(EnhancedForLoopIntArray.class), 0.01);
+	}
+
+	@Test
 	public void testFloatArray() throws Exception {
 		assertCodeContains(Float32ArrayInit.class, "new Float32Array(1)");
 	}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Types.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Types.java
@@ -1,0 +1,13 @@
+package org.stjs.generator.writer.typedarrays;
+
+public class Types {
+	public void init() {
+		byte[] b = {};
+		short[] s = {};
+		char[] c = {};
+		int[] i = {};
+		float[] f = {};
+		double[] d = {};
+	}
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/typedarrays/Types.java
+++ b/generator/src/test/java/org/stjs/generator/writer/typedarrays/Types.java
@@ -2,6 +2,7 @@ package org.stjs.generator.writer.typedarrays;
 
 public class Types {
 	public void init() {
+		boolean[] bool = {};
 		byte[] b = {};
 		short[] s = {};
 		char[] c = {};

--- a/generator/src/test/java/org/stjs/generator/writer/types/Types2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/types/Types2.java
@@ -1,5 +1,5 @@
 package org.stjs.generator.writer.types;
 
 public class Types2 {
-	private String[] abc;
+	private String[] abc = {"hello", "world", null};
 }

--- a/generator/src/test/java/org/stjs/generator/writer/types/TypesGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/types/TypesGeneratorTest.java
@@ -10,9 +10,8 @@ public class TypesGeneratorTest extends AbstractStjsTest {
 		assertCodeContains(Types1.class, "var Types1 = function(){};");
 	}
 
-	@Test(expected = JavascriptFileGenerationException.class)
 	public void testForbidArrays() {
-		generate(Types2.class);
+		assertCodeContains(Types1.class, "var abc = [\"hello\", \"world\", null];");
 	}
 
 	@Test


### PR DESCRIPTION
Basically this:

```java
String[] a = new String[]{"a", "b"}
int[] i = new int[]{1,2,3}
byte b = (byte) 'A';
```

```javascript
var a = ["a", "b"];
var i = new Int32Array([1,2,3]);
var b = 'A'.charCodeAt(0) << 24 >> 24;
```

more details here
https://github.com/zhuker/st-js/tree/typed-arrays#notes-on-primitivesarrays-support

NOTE: I have not made any attempt to make `stjs.typefy` work with this PR

## Backwards compatibility

This is not planned to be a replacement for stjs `Array<String>`.
`String[]` and `Array<String>` are compatible in JS.

```java
Array<String> a1 = JSCollections.$array("hello", "world");
String[] a2 = new String[]{"hello", "world"};
```
is equivalent to
```javascript
var a1 = ["hello", "world"];
var a2 = ["hello", "world"];
```

If you need extended array operations (e.g. `push`, `filter` etc) you can still use `$castArray()`
```java
String[] javaArray = {"hello", "world"};
Array<String> a = $castArray(javaArray);
a.push("42");
```

produces:

```javascript
var javaArray = ["hello", "world"];
var a = javaArray;
a.push("42");
```

